### PR TITLE
Escape Xcode Plug-ins path

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Alcatraz is an open-source package manager for Xcode. It lets you discover and i
 Open up your terminal, and paste this:
 
 ```
-mkdir -p '~/Library/Application Support/Developer/Shared/Xcode/Plug-ins';
+mkdir -p ~/Library/Application\ Support/Developer/Shared/Xcode/Plug-ins;
 curl -L http://goo.gl/xfmmt | tar xv -C ~/Library/Application\ Support/Developer/Shared/Xcode/Plug-ins -
 ```
 


### PR DESCRIPTION
Single quotes weren't sufficient for the 'Application Support' part,
at least on my zsh setup. Backslash should be more portable.
