### PR TITLE
Only load if current application is Xcode

### DIFF
--- a/Alcatraz/Alcatraz.m
+++ b/Alcatraz/Alcatraz.m
@@ -35,9 +35,13 @@
 + (void)pluginDidLoad:(NSBundle *)plugin {
     static Alcatraz *sharedPlugin;
     static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        sharedPlugin = [[self alloc] initWithBundle:plugin];
-    });
+    NSString *currentApplicationName = [[NSBundle mainBundle] infoDictionary][@"CFBundleName"];
+
+    if ([currentApplicationName isEqual:@"Xcode"]) {
+        dispatch_once(&onceToken, ^{
+            sharedPlugin = [[self alloc] initWithBundle:plugin];
+        });
+    }
 }
 
 - (id)initWithBundle:(NSBundle *)plugin {


### PR DESCRIPTION
## Changes
- Checks the application name of what is currently loading plugins, only loading the plugin for Xcode
- Avoids loading plugin for unsupported apps, like FileMerge, fixing #50

Thoughts?
