### PR TITLE
Support for Xcode5-DP3

### DIFF
--- a/Alcatraz/Alcatraz-Info.plist
+++ b/Alcatraz/Alcatraz-Info.plist
@@ -22,6 +22,10 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>DVTPlugInCompatibilityUUIDs</key>
+	<array>
+		<string>63FC1C47-140D-42B0-BB4D-A10B2D225574</string>
+	</array>
 	<key>XC4Compatible</key>
 	<true/>
 	<key>XCGCReady</key>


### PR DESCRIPTION
Thanks to gfontenot: https://github.com/JugglerShu/XVim/pull/404 for pointing this out

It looks like in the future we'll have to add a UUID for each new build of Xcode
