### PR TITLE
Support Checking Compatibility of Packages based on Xcode Version

### DIFF
--- a/Alcatraz/Alcatraz.h
+++ b/Alcatraz/Alcatraz.h
@@ -26,5 +26,9 @@
 @interface Alcatraz : NSObject
 
 @property (nonatomic, retain) ATZPluginWindowController *windowController;
+@property (nonatomic, strong) NSString *xcodeMajorVersion;
+@property (nonatomic, strong) NSString *xcodeMinorVersion;
+
++ (Alcatraz *)sharedPlugin;
 
 @end

--- a/Alcatraz/Alcatraz.m
+++ b/Alcatraz/Alcatraz.m
@@ -26,14 +26,15 @@
 #import "ATZAlcatrazPackage.h"
 #import "ATZShell.h"
 
-@interface Alcatraz(){}
-@property (nonatomic, retain) NSBundle *bundle;
+static Alcatraz *sharedPlugin;
+
+@interface Alcatraz()
+@property (nonatomic, strong) NSBundle *bundle;
 @end
 
 @implementation Alcatraz
 
 + (void)pluginDidLoad:(NSBundle *)plugin {
-    static Alcatraz *sharedPlugin;
     static dispatch_once_t onceToken;
     NSString *currentApplicationName = [[NSBundle mainBundle] infoDictionary][@"CFBundleName"];
 
@@ -44,9 +45,17 @@
     }
 }
 
++ (Alcatraz *)sharedPlugin {
+    return sharedPlugin;
+}
+
 - (id)initWithBundle:(NSBundle *)plugin {
     if (self = [super init]) {
         self.bundle = plugin;
+        NSString *xcodeVersion = [[NSBundle mainBundle] infoDictionary][@"CFBundleShortVersionString"];
+        NSArray *components = [xcodeVersion componentsSeparatedByString:@"."];
+        self.xcodeMajorVersion = components[0];
+        self.xcodeMinorVersion = components[1];
         [self createMenuItem];
         [self updateAlcatraz];
     }

--- a/Alcatraz/Packages/ATZPackage.h
+++ b/Alcatraz/Packages/ATZPackage.h
@@ -25,9 +25,10 @@
 @class ATZInstaller;
 
 
-@interface ATZPackage :NSObject
+@interface ATZPackage : NSObject
 
 @property (strong, nonatomic) NSString *name;
+@property (strong, nonatomic) NSString *xcodeVersion;
 @property (strong, nonatomic) NSString *description;
 @property (strong, nonatomic) NSString *type;
 @property (strong, nonatomic) NSString *remotePath;
@@ -48,6 +49,7 @@
 
 - (void)removeWithCompletion:(void(^)(NSError *failure))completion;
 
+- (BOOL)isCompatibleWithXcode;
 
 #pragma mark - Abstract
 

--- a/Alcatraz/Packages/ATZPackage.m
+++ b/Alcatraz/Packages/ATZPackage.m
@@ -23,6 +23,7 @@
 #import "ATZPackage.h"
 #import "ATZInstaller.h"
 #import "ATZGit.h"
+#import "Alcatraz.h"
 
 @implementation ATZPackage
 @dynamic isInstalled, type, website, extension;
@@ -44,6 +45,16 @@
     [super dealloc];
 }
 
+- (BOOL)isCompatibleWithXcode {
+    if (!self.xcodeVersion) return YES;
+    NSArray *components = [self.xcodeVersion componentsSeparatedByString:@"."];
+    if (components.count == 1) {
+        return [[Alcatraz sharedPlugin].xcodeMajorVersion isEqualToString:components[0]];
+    } else {
+        return [[Alcatraz sharedPlugin].xcodeMajorVersion isEqualToString:components[0]]
+            && [[Alcatraz sharedPlugin].xcodeMinorVersion isEqualToString:components[1]];
+    }
+}
 
 #pragma mark - Private
 
@@ -52,6 +63,7 @@
     self.description = dictionary[@"description"];
     self.remotePath = dictionary[@"url"];
     self.screenshotPath = dictionary[@"screenshot"];
+    self.xcodeVersion = dictionary[@"xcode_version"];
     self.revision = [ATZGit parseRevisionFromDictionary:dictionary];
 }
 

--- a/Alcatraz/Packages/ATZPackageFactory.m
+++ b/Alcatraz/Packages/ATZPackageFactory.m
@@ -46,7 +46,9 @@ static NSDictionary *packageClasses;
             
             for (NSDictionary *packageDict in packagesInDicts[packageType]) {
                 ATZPackage *package = [[packageClasses[packageType] alloc] initWithDictionary:packageDict];
-                [packages addObject:package];
+                if ([package isCompatibleWithXcode]) {
+                    [packages addObject:package];
+                }
                 [package release];
             }
         

--- a/AlcatrazTests/Packages/ATZPackageTests.m
+++ b/AlcatrazTests/Packages/ATZPackageTests.m
@@ -9,6 +9,7 @@
 #import "Kiwi.h"
 #import "ATZPackage.h"
 #import "ATZInstaller.h"
+#import "Alcatraz.h"
 
 void buildMockInstaller(KWMock *mockInstaller) {
     [mockInstaller stub:@selector(installPackage:progress:completion:) withBlock:^id(NSArray *params) {
@@ -90,6 +91,43 @@ describe(@"Package", ^{
             [[newPackage.revision should] equal:@"23kjnrq98kcq2jn"];
         });
         
+    });
+
+    describe(@"Xcode compatibility checking", ^{
+
+        __block Alcatraz *mockATZ;
+
+        beforeEach(^{
+            mockATZ = [Alcatraz mock];
+            [Alcatraz stub:@selector(sharedPlugin) andReturn:mockATZ];
+            [mockATZ stub:@selector(xcodeMajorVersion) andReturn:@"17"];
+            [mockATZ stub:@selector(xcodeMinorVersion) andReturn:@"5"];
+        });
+
+        it(@"assumes compatibility based on major version", ^{
+            ATZPackage *newPackage = [[ATZPackage alloc] initWithDictionary:@{ @"xcode_version": @"17" }];
+            [[theValue([newPackage isCompatibleWithXcode]) should] equal:theValue(YES)];
+        });
+
+        it(@"assumes compatibility based on major and minor version", ^{
+            ATZPackage *newPackage = [[ATZPackage alloc] initWithDictionary:@{ @"xcode_version": @"17.5" }];
+            [[theValue([newPackage isCompatibleWithXcode]) should] equal:theValue(YES)];
+        });
+
+        it(@"assumes compatibility when package version is not specified", ^{
+            ATZPackage *newPackage = [[ATZPackage alloc] initWithDictionary:@{}];
+            [[theValue([newPackage isCompatibleWithXcode]) should] equal:theValue(YES)];
+        });
+
+        it(@"rejects based on non-matching major version", ^{
+            ATZPackage *newPackage = [[ATZPackage alloc] initWithDictionary:@{ @"xcode_version": @"1" }];
+            [[theValue([newPackage isCompatibleWithXcode]) should] equal:theValue(NO)];
+        });
+
+        it(@"rejects based on non-matching minor version", ^{
+            ATZPackage *newPackage = [[ATZPackage alloc] initWithDictionary:@{ @"xcode_version": @"17.1" }];
+            [[theValue([newPackage isCompatibleWithXcode]) should] equal:theValue(NO)];
+        });
     });
     
     describe(@"installing", ^{


### PR DESCRIPTION
### Summary

This is a small change with a lot of far reaching effects. :smile: The immediate effect is that nothing will happen, but once the XC5 branch is production ready, we can support users having Alcatraz for multiple versions of Xcode. We will need to require an `xcode_version` property on plugin packages, and have it optionally available to other package types, in case of compatibility concerns. Changing this functionality now gives us time to have the change propagate to users before package versioning becomes an issue.
### Changes
- Add an `xcodeVersion` property to packages, translated from `xcode_version` in package JSON. This will validate that the package is compatible with the currently running version of Xcode, otherwise exclude it from the package list. If the value is nil, (like all packages at the moment, until `xcode_versioning` branch is merged into `alcatraz-packages`) then compatibility is assumed. `xcode_version` property can be formatted like `"4"` or `"4.6"`.
### Concerns
- Each plugin determines its own installation directory, and if a user is switching between XC versions, the Alcatraz update process could overwrite one version's plugin with the other. (e.g. XVim for Xcode4 being overwritten by XVim for Xcode5, if entries for both versions exist in `alcatraz-packages`)

Thoughts?
