### PR TITLE
Adding Xcode 5 GM compatibility UUID, recommended XC5 project settings.

### DIFF
--- a/Alcatraz.xcodeproj/project.pbxproj
+++ b/Alcatraz.xcodeproj/project.pbxproj
@@ -39,7 +39,6 @@
 		8966AFCF173EB7BF004150C0 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8966AFCE173EB7BF004150C0 /* Cocoa.framework */; };
 		8966AFD9173EB7BF004150C0 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 8966AFD7173EB7BF004150C0 /* InfoPlist.strings */; };
 		8966AFDC173EB7BF004150C0 /* AlcatrazTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8966AFDB173EB7BF004150C0 /* AlcatrazTests.m */; };
-		8966AFE2173EB8DB004150C0 /* Pods-AlcatrazTests.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 2A9816423A9B4C04AA35F239 /* Pods-AlcatrazTests.xcconfig */; };
 		897F7899173FC54C006C43E5 /* ATZAlcatrazPackage.m in Sources */ = {isa = PBXBuildFile; fileRef = 897F7898173FC54C006C43E5 /* ATZAlcatrazPackage.m */; };
 		89B4F2BE172FF5AC001FD2E3 /* ATZPBXProjParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 89B4F2BD172FF5AC001FD2E3 /* ATZPBXProjParser.m */; };
 		89C4C686171F1B5C004A88E7 /* PluginWindow.xib in Resources */ = {isa = PBXBuildFile; fileRef = 89C4C685171F1B5C004A88E7 /* PluginWindow.xib */; };
@@ -438,7 +437,7 @@
 			isa = PBXProject;
 			attributes = {
 				CLASSPREFIX = ATZ;
-				LastUpgradeCheck = 0460;
+				LastUpgradeCheck = 0500;
 				ORGANIZATIONNAME = mneorr.com;
 			};
 			buildConfigurationList = 890A4B3A171F031300AFE577 /* Build configuration list for PBXProject "Alcatraz" */;
@@ -479,7 +478,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				8966AFD9173EB7BF004150C0 /* InfoPlist.strings in Resources */,
-				8966AFE2173EB8DB004150C0 /* Pods-AlcatrazTests.xcconfig in Resources */,
 				8AD524A0174102F9008B451F /* Localizable.strings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -630,7 +628,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
@@ -662,7 +659,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_WARN_CONSTANT_CONVERSION = YES;

--- a/Alcatraz.xcodeproj/xcshareddata/xcschemes/Alcatraz.xcscheme
+++ b/Alcatraz.xcodeproj/xcshareddata/xcschemes/Alcatraz.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0460"
+   LastUpgradeVersion = "0500"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "NO"
@@ -14,7 +14,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "5406B554185C4EF59FDCCBD6"
+               BlueprintIdentifier = "750CF5553C2E4639B3B93A91"
                BuildableName = "libPods-AlcatrazTests.a"
                BlueprintName = "Pods-AlcatrazTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">

--- a/Alcatraz.xcodeproj/xcshareddata/xcschemes/AlcatrazTests.xcscheme
+++ b/Alcatraz.xcodeproj/xcshareddata/xcschemes/AlcatrazTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0460"
+   LastUpgradeVersion = "0500"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Alcatraz.xcworkspace/xcshareddata/Alcatraz.xccheckout
+++ b/Alcatraz.xcworkspace/xcshareddata/Alcatraz.xccheckout
@@ -2,37 +2,39 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>IDESourceControlProjectFavoriteDictionaryKey</key>
+	<false/>
 	<key>IDESourceControlProjectIdentifier</key>
-	<string>9604916A-B837-4929-84A9-59EA07FF2DBA</string>
+	<string>38B742B6-2093-40A5-BC0A-273FB94806A7</string>
 	<key>IDESourceControlProjectName</key>
 	<string>Alcatraz</string>
 	<key>IDESourceControlProjectOriginsDictionary</key>
 	<dict>
-		<key>B1A1ED2A-BDF6-4A7F-8C75-750A276E7008</key>
-		<string>ssh://github.com/mneorr/Alcatraz.git</string>
+		<key>B4037A07-3AE3-4A23-B77D-6F363F0C4B18</key>
+		<string>ssh://github.com/kreeger/Alcatraz.git</string>
 	</dict>
 	<key>IDESourceControlProjectPath</key>
 	<string>Alcatraz.xcworkspace</string>
 	<key>IDESourceControlProjectRelativeInstallPathDictionary</key>
 	<dict>
-		<key>B1A1ED2A-BDF6-4A7F-8C75-750A276E7008</key>
+		<key>B4037A07-3AE3-4A23-B77D-6F363F0C4B18</key>
 		<string>..</string>
 	</dict>
 	<key>IDESourceControlProjectURL</key>
-	<string>ssh://github.com/mneorr/Alcatraz.git</string>
+	<string>ssh://github.com/kreeger/Alcatraz.git</string>
 	<key>IDESourceControlProjectVersion</key>
 	<integer>110</integer>
 	<key>IDESourceControlProjectWCCIdentifier</key>
-	<string>B1A1ED2A-BDF6-4A7F-8C75-750A276E7008</string>
+	<string>B4037A07-3AE3-4A23-B77D-6F363F0C4B18</string>
 	<key>IDESourceControlProjectWCConfigurations</key>
 	<array>
 		<dict>
 			<key>IDESourceControlRepositoryExtensionIdentifierKey</key>
 			<string>public.vcs.git</string>
 			<key>IDESourceControlWCCIdentifierKey</key>
-			<string>B1A1ED2A-BDF6-4A7F-8C75-750A276E7008</string>
+			<string>B4037A07-3AE3-4A23-B77D-6F363F0C4B18</string>
 			<key>IDESourceControlWCCName</key>
-			<string>alcatraz</string>
+			<string>Alcatraz</string>
 		</dict>
 	</array>
 </dict>

--- a/Alcatraz/Alcatraz-Info.plist
+++ b/Alcatraz/Alcatraz-Info.plist
@@ -2,12 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>DVTPlugInCompatibilityUUIDs</key>
-	<array>
-		<string>63FC1C47-140D-42B0-BB4D-A10B2D225574</string>
-	</array>
-	<key>XC5Compatible</key>
-	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>English</string>
 	<key>CFBundleExecutable</key>
@@ -28,7 +22,14 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>DVTPlugInCompatibilityUUIDs</key>
+	<array>
+		<string>63FC1C47-140D-42B0-BB4D-A10B2D225574</string>
+		<string>37B30044-3B14-46BA-ABAA-F01000C27B63</string>
+	</array>
 	<key>XC4Compatible</key>
+	<true/>
+	<key>XC5Compatible</key>
 	<true/>
 	<key>XCGCReady</key>
 	<true/>


### PR DESCRIPTION
I always find XVim is ahead of the curve when it comes to Xcode version compatibility, so I've followed [one of their latest changes](https://github.com/JugglerShu/XVim/pull/441/files) to do the same for Alcatraz. Let me know if you'd like anything else in this PR; I'm happy to accommodate!
