### PR TITLE
Update .gitignore with new Xcode5 files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,8 @@ profile
 DerivedData
 .idea/
 *.hmapods/*
+*.hmap
+*.xccheckout
+
+#CocoaPods
 Pods


### PR DESCRIPTION
Update of the `.gitignore` based on https://github.com/github/gitignore/blob/master/Objective-C.gitignore.

In particular, add `*.xccheckout`.
