### PR TITLE
Do not build target Alcatraz-Test when running (only when testing)

### DIFF
--- a/Alcatraz.xcodeproj/xcshareddata/xcschemes/Alcatraz.xcscheme
+++ b/Alcatraz.xcodeproj/xcshareddata/xcschemes/Alcatraz.xcscheme
@@ -36,7 +36,7 @@
          </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
-            buildForRunning = "YES"
+            buildForRunning = "NO"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
             buildForAnalyzing = "NO">


### PR DESCRIPTION
Uncheck AlcatrazTests to be builded when running. This allow anyone to build the most recent version of Alcatraz without having to install CocoaPods.
See https://github.com/mneorr/Alcatraz/pull/84#issuecomment-29205131.

![alcatraz-schemes-test](https://f.cloud.github.com/assets/1041337/1616015/a975390a-5603-11e3-9d94-74eb3da75e75.png)
