### PR TITLE
Update PluginWindow.xib

### DIFF
--- a/Alcatraz/PluginWindow.xib
+++ b/Alcatraz/PluginWindow.xib
@@ -132,7 +132,7 @@
                                                             <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                                             <font key="titleFont" metaFont="system"/>
                                                         </box>
-                                                        <customView focusRingType="none" appearanceType="lightContent" translatesAutoresizingMaskIntoConstraints="NO" id="R0c-wL-QhR">
+                                                        <customView focusRingType="none" appearanceType="Light Content" translatesAutoresizingMaskIntoConstraints="NO" id="R0c-wL-QhR">
                                                             <rect key="frame" x="421" y="3" width="29" height="59"/>
                                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                             <subviews>


### PR DESCRIPTION
Without change Xcode crashed whenever I tried to view PluginWindow.xib in in Xcode Version 5.0.2 (5A3005)
Also before chance was unable to build project due to the Compile Error: 
 "Command /Applications/Xcode.app/Contents/Developer/usr/bin/ibtool failed  with exit code 255"
