### PR TITLE
Remove "Appearance" from Custom View.

### DIFF
--- a/Alcatraz/PluginWindow.xib
+++ b/Alcatraz/PluginWindow.xib
@@ -129,7 +129,7 @@
                                                             <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                                             <font key="titleFont" metaFont="system"/>
                                                         </box>
-                                                        <customView focusRingType="none" appearanceType="lightContent" translatesAutoresizingMaskIntoConstraints="NO" id="R0c-wL-QhR">
+                                                        <customView focusRingType="none" translatesAutoresizingMaskIntoConstraints="NO" id="R0c-wL-QhR">
                                                             <rect key="frame" x="421" y="3" width="29" height="59"/>
                                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                             <subviews>


### PR DESCRIPTION
This allows building on 10.8.

Note that opening the plugin window causes Xcode to crash, however I
suspect the crash is unrelated as removing this attribute is the same as
not specifying a custom 'Appearance' in the first place.

Related, IB in Xcode 5.0.2 on 10.8 has no 'Appearance' option for
NSViews, where as Xcode 5.0.2 on 10.9 does.

Closes #107
