### PR TITLE
Replaced a couple of 10.9-only methods with more available ones

### DIFF
--- a/Alcatraz/Categories/NSColor+Alcatraz.m
+++ b/Alcatraz/Categories/NSColor+Alcatraz.m
@@ -31,7 +31,7 @@
 
 + (instancetype)alcatrazProgressGrayColor
 {
-    return [NSColor colorWithWhite:0.5 alpha:0.9];;
+    return [NSColor colorWithDeviceRed:0.5 green:0.5 blue:0.5 alpha:0.9];
 }
 
 @end

--- a/Alcatraz/Views/ATZRadialProgressControl.m
+++ b/Alcatraz/Views/ATZRadialProgressControl.m
@@ -45,7 +45,7 @@ const CGFloat ATZRadialProgressControl_FakeRemoveProgress = 0.66;
                                                                         package:package
                                                                            size:bounds.size
                                                                           color:self.tintColor];
-    [image drawInRect:bounds];
+    [image drawInRect:bounds fromRect:NSZeroRect operation:NSCompositeSourceOver fraction:1 respectFlipped:YES hints:nil];
 }
 
 + (id)defaultAnimationForKey:(NSString *)key


### PR DESCRIPTION
Hey! I tried to install Alcatraz on Mountain Lion and it seemed like some of Mavericks-only methods were used. Guess they can replaced without harm :)
