### PR TITLE
Fix tar command to work with both GNU and BSD tar

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ To install, open up your terminal and paste this:
 
 ``` bash
 mkdir -p ~/Library/Application\ Support/Developer/Shared/Xcode/Plug-ins;
-curl -L http://goo.gl/zoAnfh | tar xv -C ~/Library/Application\ Support/Developer/Shared/Xcode/Plug-ins -
+curl -L http://goo.gl/zoAnfh | tar xvz -C ~/Library/Application\ Support/Developer/Shared/Xcode/Plug-ins
 ```
 or download the repository from Github and build it in Xcode. You'll need to restart Xcode after the installation.
 


### PR DESCRIPTION
Prevent install failure if the user's `tar` command is GNU tar (e.g. because they installed that via Fink / MacPorts / Homebrew). The revised instructions work with Apple's BSD tar just as well as with GNU tar.
