### PR TITLE
Present alert for users on OS X 10.8

### DIFF
--- a/Alcatraz/Alcatraz.m
+++ b/Alcatraz/Alcatraz.m
@@ -68,11 +68,14 @@ static Alcatraz *sharedPlugin;
 }
 
 - (void)checkForCMDLineToolsAndOpenWindow {
-    
-    if ([ATZGit areCommandLineToolsAvailable])
-        [self loadWindowAndPutInFront];
-    else
-        [self presentAlertForInstallingCMDLineTools];
+    if ([self hasNSURLSessionAvailable]) {
+        if ([ATZGit areCommandLineToolsAvailable])
+            [self loadWindowAndPutInFront];
+        else
+            [self presentAlertWithMessageKey:@"CMDLineToolsWarning"];
+    } else {
+        [self presentAlertWithMessageKey:@"MavericksOnlyWarning"];
+    }
 }
 
 - (void)loadWindowAndPutInFront {
@@ -83,8 +86,12 @@ static Alcatraz *sharedPlugin;
     [self.windowController reloadPackages];
 }
 
-- (void)presentAlertForInstallingCMDLineTools {
-    NSAlert *alert = [NSAlert alertWithMessageText:[self.bundle localizedStringForKey:@"CMDLineToolsWarning" value:nil table:nil]
+- (BOOL)hasNSURLSessionAvailable {
+    return NSClassFromString(@"NSURLSession") != nil;
+}
+
+- (void)presentAlertWithMessageKey:(NSString *)messageKey {
+    NSAlert *alert = [NSAlert alertWithMessageText:[self.bundle localizedStringForKey:messageKey value:nil table:nil]
                                      defaultButton:nil
                                    alternateButton:nil
                                        otherButton:nil

--- a/Alcatraz/en.lproj/Localizable.strings
+++ b/Alcatraz/en.lproj/Localizable.strings
@@ -8,3 +8,5 @@
 "CMDLineToolsWarning" = "Xcode Command Line Tools are not currently installed, and are required to run Alcatraz.
 
 Command Line Tools are available for installation in the Downloads section of Preferences.";
+
+"MavericksOnlyWarning" = "Alcatraz for Xcode 5 only supports OS X 10.9+.";


### PR DESCRIPTION
Alcatraz only supports 10.9+ at the moment, because the download indicator uses `NSURLSession`. This presents a helpful alert to users on OS X 10.8 and prevents a crash.
