### PR TITLE
typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,7 +97,7 @@ curl -L http://git.io/lOQWeA | tar xvz -C ~/Library/Application\ Support/Develop
     <h3>Uninstall</h3>
     <p>
       Delete the plugin:
-      <pre>~/Library/Application\ Support/Developer/Shared/Xcode/Plug-ins/Alcatraz.xcplugin</pre>
+      <pre>rm -rf ~/Library/Application\ Support/Developer/Shared/Xcode/Plug-ins/Alcatraz.xcplugin</pre>
       Remove all cached data:
       <pre>rm -rf ~/Library/Application\ Support/Alcatraz/</pre>
     </p>


### PR DESCRIPTION
Was missing the required `rm -rf` in uninstallation instructions.
