### PR TITLE
Fixed missing quote for creating PLUGINS_DIR

### DIFF
--- a/Scripts/install.sh
+++ b/Scripts/install.sh
@@ -1,7 +1,7 @@
 DOWNLOAD_URI=https://github.com/supermarin/Alcatraz/releases/download/1.0.1/Alcatraz.tar.gz
 PLUGINS_DIR="${HOME}/Library/Application Support/Developer/Shared/Xcode/Plug-ins"
 
-mkdir -p $PLUGINS_DIR
+mkdir -p "$PLUGINS_DIR"
 curl -L $DOWNLOAD_URI | tar xvz -C "${PLUGINS_DIR}"
 
 echo "Alcatraz successfuly installed!!1!🍻   Please restart your Xcode."


### PR DESCRIPTION
Resulting in this install error: 

```
 $ curl -fsSL https://raw.github.com/supermarin/Alcatraz/master/Scripts/install.sh | sh
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   342  100   342    0     0    457      0 --:--:-- --:--:-- --:--:--   457
  0     0    0     0    0     0      0      0 --:--:--  0:00:02 --:--:--     0tar: could not chdir to '/Users/jean/Library/Application Support/Developer/Shared/Xcode/Plug-ins'

 62 85370   62 53441    0     0  15883      0  0:00:05  0:00:03  0:00:02 24391
curl: (23) Failed writing body (0 != 9000)
Alcatraz successfuly installed!!1!   Please restart your Xcode.
```
