### PR TITLE
Added shebang line and fixed typo in success message

### DIFF
--- a/Scripts/install.sh
+++ b/Scripts/install.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 DOWNLOAD_URI=https://github.com/supermarin/Alcatraz/releases/download/1.0.4/Alcatraz.tar.gz
 PLUGINS_DIR="${HOME}/Library/Application Support/Developer/Shared/Xcode/Plug-ins"
 


### PR DESCRIPTION
Just added the shebang line to the installation script and fixed a typo in the success message.
