### PR TITLE
Insert menu item before "Bring All to Front"

### DIFF
--- a/Alcatraz/Alcatraz.m
+++ b/Alcatraz/Alcatraz.m
@@ -63,8 +63,9 @@ static Alcatraz *sharedPlugin;
                                                         keyEquivalent:@"9"];
     pluginManagerItem.keyEquivalentModifierMask = NSCommandKeyMask | NSShiftKeyMask;
     pluginManagerItem.target = self;
+
     [windowMenuItem.submenu insertItem:pluginManagerItem
-                               atIndex:[windowMenuItem.submenu indexOfItemWithTitle:@"Organizer"] + 1];
+                               atIndex:[windowMenuItem.submenu indexOfItemWithTitle:@"Bring All to Front"] - 1];
 }
 
 - (void)checkForCMDLineToolsAndOpenWindow {

--- a/Specs/AlcatrazSpec.m
+++ b/Specs/AlcatrazSpec.m
@@ -33,7 +33,9 @@ NSMenu *createFakeMenu() {
     NSMenuItem *windowMenu = [[NSMenuItem alloc] initWithTitle:@"Window" action:nil keyEquivalent:@""];
     windowMenu.submenu = [[NSMenu alloc] initWithTitle:@"FakeSubmenu"];
     [windowMenu.submenu addItemWithTitle:@"Organizer" action:nil keyEquivalent:@""];
-    
+    [windowMenu.submenu addItem:[NSMenuItem separatorItem]];
+    [windowMenu.submenu addItemWithTitle:@"Bring All to Front" action:nil keyEquivalent:@""];
+
     [fakeMenu addItem:windowMenu];
     return fakeMenu;
 }


### PR DESCRIPTION
There's a lot of real estate between that ⇧⌘2 and ⇧⌘9.

For example, [Attica](https://github.com/kattrali/attica) uses ⇧⌘8, and because of Xcode plug-in load order, it's inserted after Alcatraz, yielding a menu that looks like this:

```
Documentation and API Reference  ⇧⌘0
Welcome to Xcode                 ⇧⌘1
Organizer                        ⇧⌘2
Package Manager                  ⇧⌘9
Snippet Editor                   ⇧⌘8
```

If we insert the item before the section's separator item, we can cure my mild case of OCD.
