### PR TITLE
Support OS X 10.10

### DIFF
--- a/Alcatraz/Helpers/ATZDownloader.m
+++ b/Alcatraz/Helpers/ATZDownloader.m
@@ -92,6 +92,10 @@ static NSString *const COMPLETION = @"completion";
 
 - (void)URLSession:(NSURLSession *)session downloadTask:(NSURLSessionDownloadTask *)downloadTask didResumeAtOffset:(int64_t)fileOffset expectedTotalBytes:(int64_t)expectedTotalBytes {}
 
+- (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task willPerformHTTPRedirection:(NSHTTPURLResponse *)response newRequest:(NSURLRequest *)request completionHandler:(void (^)(NSURLRequest *))completionHandler {
+    completionHandler(request);
+}
+
 
 #pragma mark - NSURLSessionTask delegate
 


### PR DESCRIPTION
Redirect for the `packages.json` isn't followed on 10.10 without implementing the corresponding delegate method, so this fixes it.
