### PR TITLE
Changed installer to address #281

### DIFF
--- a/Scripts/install.sh
+++ b/Scripts/install.sh
@@ -6,5 +6,7 @@ PLUGINS_DIR="${HOME}/Library/Application Support/Developer/Shared/Xcode/Plug-ins
 mkdir -p "${PLUGINS_DIR}"
 curl -L $DOWNLOAD_URI | tar xvz -C "${PLUGINS_DIR}"
 
+defaults delete com.apple.dt.Xcode.plist DVTPlugInManagerNonApplePlugIns-Xcode-6.3.2 2> /dev/null
+
 echo "Alcatraz successfully installed!!1!🍻   Please restart your Xcode."
 

--- a/Scripts/install.sh
+++ b/Scripts/install.sh
@@ -6,7 +6,7 @@ PLUGINS_DIR="${HOME}/Library/Application Support/Developer/Shared/Xcode/Plug-ins
 mkdir -p "${PLUGINS_DIR}"
 curl -L $DOWNLOAD_URI | tar xvz -C "${PLUGINS_DIR}"
 
-defaults delete com.apple.dt.Xcode.plist DVTPlugInManagerNonApplePlugIns-Xcode-6.3.2 2> /dev/null
+defaults delete com.apple.dt.Xcode DVTPlugInManagerNonApplePlugIns-Xcode-6.3.2 2> /dev/null
 
 echo "Alcatraz successfully installed!!1!🍻   Please restart your Xcode."
 


### PR DESCRIPTION
Installer script will now remove blacklisted plugins, so the user is prompted to load them upon restarting Xcode. (see #281)