### PR TITLE
Display blocked plugins

### DIFF
--- a/Alcatraz.xcodeproj/project.pbxproj
+++ b/Alcatraz.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		8ADC22341A2AD5B800DB7BCA /* ATZPreviewImageButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 8ADC22331A2AD5B800DB7BCA /* ATZPreviewImageButton.m */; };
 		8AF670C919C2DE8A00E1C168 /* ATZSegmentedControl.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AF670C819C2DE8A00E1C168 /* ATZSegmentedControl.m */; };
 		F0DF961E1B40416400DF68CC /* ATZSegmentedCell.m in Sources */ = {isa = PBXBuildFile; fileRef = F0DF961D1B40416400DF68CC /* ATZSegmentedCell.m */; };
+		F07E55521B551BA800161E61 /* ATZXcodePrefsManager.m in Sources */ = {isa = PBXBuildFile; fileRef = F07E55511B551BA800161E61 /* ATZXcodePrefsManager.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -145,6 +146,8 @@
 		8AF670C819C2DE8A00E1C168 /* ATZSegmentedControl.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ATZSegmentedControl.m; path = Views/ATZSegmentedControl.m; sourceTree = "<group>"; };
 		F0DF961C1B40416300DF68CC /* ATZSegmentedCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ATZSegmentedCell.h; sourceTree = "<group>"; };
 		F0DF961D1B40416400DF68CC /* ATZSegmentedCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ATZSegmentedCell.m; sourceTree = "<group>"; };
+		F07E55501B551BA800161E61 /* ATZXcodePrefsManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ATZXcodePrefsManager.h; sourceTree = "<group>"; };
+		F07E55511B551BA800161E61 /* ATZXcodePrefsManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ATZXcodePrefsManager.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -300,6 +303,8 @@
 				8917DA171726B63B00F0B2D2 /* ATZShell.m */,
 				89B4F2BC172FF5AC001FD2E3 /* ATZPBXProjParser.h */,
 				89B4F2BD172FF5AC001FD2E3 /* ATZPBXProjParser.m */,
+				F07E55501B551BA800161E61 /* ATZXcodePrefsManager.h */,
+				F07E55511B551BA800161E61 /* ATZXcodePrefsManager.m */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -464,6 +469,7 @@
 				8A1732A81A2694BB002033D6 /* NSColor+Alcatraz.m in Sources */,
 				894714E817302F63003CDDA7 /* ATZInstaller.m in Sources */,
 				897F7899173FC54C006C43E5 /* ATZAlcatrazPackage.m in Sources */,
+				F07E55521B551BA800161E61 /* ATZXcodePrefsManager.m in Sources */,
 				8A4C621A19C2D6F1003580BD /* ATZFilterBarView.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Alcatraz/ATZPluginWindowController.xib
+++ b/Alcatraz/ATZPluginWindowController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="9060" systemVersion="14F1021" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="9060"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="9531"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="ATZPluginWindowController">
@@ -23,7 +23,7 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES" unifiedTitleAndToolbar="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="196" y="240" width="545" height="449"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="877"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
             <view key="contentView" id="EiT-Mj-1SZ">
                 <rect key="frame" x="0.0" y="0.0" width="545" height="449"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -31,8 +31,8 @@
                     <customView translatesAutoresizingMaskIntoConstraints="NO" id="0Fa-9p-0gT" customClass="ATZFilterBarView">
                         <rect key="frame" x="0.0" y="417" width="545" height="32"/>
                         <subviews>
-                            <segmentedControl verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="reu-CB-C0i" customClass="ATZSegmentedControl">
-                                <rect key="frame" x="16" y="4" width="111" height="24"/>
+                            <segmentedControl verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="reu-CB-C0i" customClass="ATZSegmentedControl">
+                                <rect key="frame" x="16" y="4" width="111" height="25"/>
                                 <segmentedCell key="cell" borderStyle="border" alignment="left" style="separated" trackingMode="selectOne" id="5Tl-2Y-k8p">
                                     <font key="font" metaFont="system"/>
                                     <segments>
@@ -44,8 +44,8 @@
                                     <action selector="segmentedControlPressed:" target="-2" id="CPU-ex-EvU"/>
                                 </connections>
                             </segmentedControl>
-                            <segmentedControl verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Wxk-Va-YMt" customClass="ATZSegmentedControl">
-                                <rect key="frame" x="143" y="4" width="259" height="24"/>
+                            <segmentedControl verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Wxk-Va-YMt" customClass="ATZSegmentedControl">
+                                <rect key="frame" x="143" y="4" width="259" height="25"/>
                                 <segmentedCell key="cell" borderStyle="border" alignment="left" style="separated" trackingMode="selectOne" id="TlD-Cy-glk">
                                     <font key="font" metaFont="system"/>
                                     <segments>
@@ -228,7 +228,7 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES" resizable="YES" utility="YES" HUD="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="139" y="81" width="276" height="378"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="877"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
             <view key="contentView" id="WQe-dv-pdE">
                 <rect key="frame" x="0.0" y="0.0" width="276" height="378"/>
                 <autoresizingMask key="autoresizingMask"/>

--- a/Alcatraz/Controllers/ATZPackageTableViewDelegate.m
+++ b/Alcatraz/Controllers/ATZPackageTableViewDelegate.m
@@ -31,6 +31,7 @@
 #import "ATZTemplate.h"
 #import "ATZColorScheme.h"
 #import "ATZDownloader.h"
+#import "ATZStyleKit.h"
 #import "NSColor+Alcatraz.h"
 
 @interface ATZPackageTableViewDelegate ()
@@ -81,6 +82,8 @@ static CGFloat const ATZPackageCellBaseHeight = 116.f;
 - (NSView *)tableView:(NSTableView *)tableView viewForTableColumn:(NSTableColumn *)tableColumn row:(NSInteger)row {
     ATZPackage* package = [self tableView:tableView objectValueForTableColumn:tableColumn row:row];
     ATZPackageListTableCellView* view = [tableView makeViewWithIdentifier:packageCellIdentifier owner:self.tableViewOwner];
+    ATZFillableButton* installButton = (ATZFillableButton*)view.installButton;
+    [ATZStyleKit updateButton:installButton forPackageState:package animated:NO];
     [view.titleField setStringValue:package.name];
     [view.descriptionField setStringValue:package.summary];
     [view.linkButton setImage:[self tableView:tableView websiteImageForTableColumn:tableColumn row:row]];
@@ -100,18 +103,6 @@ static CGFloat const ATZPackageCellBaseHeight = 116.f;
         }
     } else {
         [view.previewButton setImage:nil];
-    }
-    
-    ATZFillableButton* installButton = (ATZFillableButton*)view.installButton;
-    if ([package isInstalled]) {
-        [installButton setTitle:@"REMOVE"];
-        [installButton setButtonStyle:ATZFillableButtonStyleRemove];
-        [installButton setFillRatio:1];
-    }
-    else {
-        [installButton setTitle:@"INSTALL"];
-        [installButton setButtonStyle:ATZFillableButtonStyleInstall];
-        [installButton setFillRatio:0];
     }
 
     return view;

--- a/Alcatraz/Controllers/ATZPackageTableViewDelegate.m
+++ b/Alcatraz/Controllers/ATZPackageTableViewDelegate.m
@@ -85,7 +85,6 @@ static CGFloat const ATZPackageCellBaseHeight = 116.f;
     [view.descriptionField setStringValue:package.summary];
     [view.linkButton setImage:[self tableView:tableView websiteImageForTableColumn:tableColumn row:row]];
     [view.linkButton setTitle:[self tableView:tableView displayWebsiteForTableColumn:tableColumn row:row]];
-    [view.installButton setTitle:([package isInstalled] ? @"REMOVE" : @"INSTALL")];
     BOOL hasImage = package.screenshotPath != nil;
     [view.previewButton setFullSize:hasImage];
     [view.previewButton setHidden:!hasImage];
@@ -104,8 +103,16 @@ static CGFloat const ATZPackageCellBaseHeight = 116.f;
     }
     
     ATZFillableButton* installButton = (ATZFillableButton*)view.installButton;
-    [installButton setButtonBorderStyle:ATZFillableButtonTypeInstall];
-    [installButton setFillRatio:([package isInstalled] ? 100 : 0) animated:NO];
+    if ([package isInstalled]) {
+        [installButton setTitle:@"REMOVE"];
+        [installButton setButtonStyle:ATZFillableButtonStyleRemove];
+        [installButton setFillRatio:1];
+    }
+    else {
+        [installButton setTitle:@"INSTALL"];
+        [installButton setButtonStyle:ATZFillableButtonStyleInstall];
+        [installButton setFillRatio:0];
+    }
 
     return view;
 }

--- a/Alcatraz/Controllers/ATZPluginWindowController.m
+++ b/Alcatraz/Controllers/ATZPluginWindowController.m
@@ -89,10 +89,18 @@ typedef NS_ENUM(NSInteger, ATZFilterSegment) {
 - (IBAction)installPressed:(ATZFillableButton *)button {
     ATZPackage *package = [self.tableViewDelegate tableView:self.tableView objectValueForTableColumn:0 row:[self.tableView rowForView:button]];
     
-    if (package.isInstalled)
-        [self removePackage:package andUpdateControl:button];
-    else
+    if (package.isInstalled) {
+        if ([package isKindOfClass:[ATZPlugin class]] && [(ATZPlugin *)package isBlacklisted]) {
+            [self whitelistPackage:(ATZPlugin *)package andUpdateControl:button];
+        }
+        else {
+            [self removePackage:package andUpdateControl:button];
+        }
+    }
+    else {
         [self installPackage:package andUpdateControl:button];
+    }
+
 }
 
 - (NSDictionary *)segmentClassMapping {
@@ -204,6 +212,13 @@ typedef NS_ENUM(NSInteger, ATZFilterSegment) {
         if (package.requiresRestart) {
             [self postNotificationForInstalledPackage:package];
         }
+    }];
+}
+
+- (void)whitelistPackage:(ATZPlugin *)package andUpdateControl:(ATZFillableButton *)button {
+    [package whitelistWithCompletion:^(NSError *failure) {
+        [ATZStyleKit updateButton:button forPackageState:package animated:YES];
+        if (package.requiresRestart) [self postNotificationForInstalledPackage:package];
     }];
 }
 

--- a/Alcatraz/Controllers/ATZPluginWindowController.m
+++ b/Alcatraz/Controllers/ATZPluginWindowController.m
@@ -26,6 +26,7 @@
 #import "ATZDownloader.h"
 #import "Alcatraz.h"
 #import "ATZPackageFactory.h"
+#import "ATZStyleKit.h"
 
 #import "ATZPlugin.h"
 #import "ATZColorScheme.h"
@@ -189,21 +190,20 @@ typedef NS_ENUM(NSInteger, ATZFilterSegment) {
 }
 
 - (void)removePackage:(ATZPackage *)package andUpdateControl:(ATZFillableButton *)button {
-    [button setButtonStyle:ATZFillableButtonStyleInstall];
-    [button setFillRatio:0 animated:YES];
-    button.title = @"INSTALL";
-    [package removeWithCompletion:NULL];
+    [package removeWithCompletion:^(NSError *failure) {
+        [ATZStyleKit updateButton:button forPackageState:package animated:YES];
+    }];
 }
 
-- (void)installPackage:(ATZPackage *)package andUpdateControl:(ATZFillableButton *)control {
+- (void)installPackage:(ATZPackage *)package andUpdateControl:(ATZFillableButton *)button {
     [package installWithProgress:^(NSString *progressMessage, CGFloat progress) {
-        control.title = @"INSTALLING";
-        [control setFillRatio:progress animated:YES];
+        button.title = @"INSTALLING";
+        [button setFillRatio:progress animated:YES];
     } completion:^(NSError *failure) {
-        [control setButtonStyle:(package.isInstalled ? ATZFillableButtonStyleRemove : ATZFillableButtonStyleInstall)];
-        control.title = package.isInstalled ? @"REMOVE" : @"INSTALL";
-        [control setFillRatio:(package.isInstalled ? 1 : 0) animated:YES];
-        if (package.requiresRestart) [self postNotificationForInstalledPackage:package];
+        [ATZStyleKit updateButton:button forPackageState:package animated:YES];
+        if (package.requiresRestart) {
+            [self postNotificationForInstalledPackage:package];
+        }
     }];
 }
 

--- a/Alcatraz/Controllers/ATZPluginWindowController.m
+++ b/Alcatraz/Controllers/ATZPluginWindowController.m
@@ -189,6 +189,7 @@ typedef NS_ENUM(NSInteger, ATZFilterSegment) {
 }
 
 - (void)removePackage:(ATZPackage *)package andUpdateControl:(ATZFillableButton *)button {
+    [button setButtonStyle:ATZFillableButtonStyleInstall];
     [button setFillRatio:0 animated:YES];
     button.title = @"INSTALL";
     [package removeWithCompletion:NULL];
@@ -197,10 +198,11 @@ typedef NS_ENUM(NSInteger, ATZFilterSegment) {
 - (void)installPackage:(ATZPackage *)package andUpdateControl:(ATZFillableButton *)control {
     [package installWithProgress:^(NSString *progressMessage, CGFloat progress) {
         control.title = @"INSTALLING";
-        [control setFillRatio:progress * 100 animated:YES];
+        [control setFillRatio:progress animated:YES];
     } completion:^(NSError *failure) {
+        [control setButtonStyle:(package.isInstalled ? ATZFillableButtonStyleRemove : ATZFillableButtonStyleInstall)];
         control.title = package.isInstalled ? @"REMOVE" : @"INSTALL";
-        [control setFillRatio:(package.isInstalled ? 100 : 0) animated:YES];
+        [control setFillRatio:(package.isInstalled ? 1 : 0) animated:YES];
         if (package.requiresRestart) [self postNotificationForInstalledPackage:package];
     }];
 }

--- a/Alcatraz/Controllers/ATZPluginWindowController.m
+++ b/Alcatraz/Controllers/ATZPluginWindowController.m
@@ -91,7 +91,7 @@ typedef NS_ENUM(NSInteger, ATZFilterSegment) {
     ATZPackage *package = [self.tableViewDelegate tableView:self.tableView objectValueForTableColumn:0 row:[self.tableView rowForView:button]];
 
     if (package.isInstalled) {
-        if ([package isKindOfClass:[ATZPlugin class]] && [(ATZPlugin *)package isBlacklisted]) {
+        if (package.isBlacklisted) {
             [self whitelistPackage:(ATZPlugin *)package andUpdateControl:button];
         }
         else {
@@ -224,9 +224,7 @@ typedef NS_ENUM(NSInteger, ATZFilterSegment) {
 }
 
 - (void)postNotificationForInstalledPackage:(ATZPackage *)package {
-    if (![NSUserNotificationCenter class] || !package.isInstalled) {
-        return;
-    }
+    if (![NSUserNotificationCenter class] || !package.isInstalled) return;
 
     NSUserNotification *notification = [NSUserNotification new];
     notification.title = [NSString stringWithFormat:@"%@ installed", package.type];

--- a/Alcatraz/Helpers/ATZStyleKit.h
+++ b/Alcatraz/Helpers/ATZStyleKit.h
@@ -24,8 +24,13 @@
 #import <Foundation/Foundation.h>
 #import <Cocoa/Cocoa.h>
 
+@class ATZFillableButton;
+@class ATZPackage;
 
 @interface ATZStyleKit : NSObject
+
+// Fillable buttons style helper
++ (void)updateButton:(ATZFillableButton *)fillableButton forPackageState:(ATZPackage *)package animated:(BOOL)animated;
 
 // Drawing Methods
 + (void)drawFillableButtonWithText:(NSString*)text fillColor:(NSColor *)fillColor backgroundColor:(NSColor *)backgroundColor fillRatio:(float)fillRatio size:(CGSize)size;

--- a/Alcatraz/Helpers/ATZStyleKit.h
+++ b/Alcatraz/Helpers/ATZStyleKit.h
@@ -28,6 +28,6 @@
 @interface ATZStyleKit : NSObject
 
 // Drawing Methods
-+ (void)drawFillableButtonWithButtonText: (NSString*)buttonText fillRatio: (CGFloat)fillRatio buttonWidth: (CGFloat)buttonWidth buttonType: (NSString*)buttonType;
++ (void)drawFillableButtonWithText:(NSString*)text fillColor:(NSColor *)fillColor backgroundColor:(NSColor *)backgroundColor fillRatio:(float)fillRatio size:(CGSize)size;
 
 @end

--- a/Alcatraz/Helpers/ATZStyleKit.m
+++ b/Alcatraz/Helpers/ATZStyleKit.m
@@ -22,9 +22,25 @@
 // THE SOFTWARE.
 
 #import "ATZStyleKit.h"
-
+#import "ATZPackage.h"
+#import "ATZFillableButton.h"
 
 @implementation ATZStyleKit
+
+#pragma mark ATZFillableButton styling
+
++ (void)updateButton:(ATZFillableButton *)fillableButton forPackageState:(ATZPackage *)package animated:(BOOL)animated {
+    if ([package isInstalled]) {
+        [fillableButton setTitle:@"REMOVE"];
+        [fillableButton setButtonStyle:ATZFillableButtonStyleRemove];
+        [fillableButton setFillRatio:1 animated:animated];
+    }
+    else {
+        [fillableButton setTitle:@"INSTALL"];
+        [fillableButton setButtonStyle:ATZFillableButtonStyleInstall];
+        [fillableButton setFillRatio:0 animated:animated];
+    }
+}
 
 #pragma mark Drawing Methods
 

--- a/Alcatraz/Helpers/ATZStyleKit.m
+++ b/Alcatraz/Helpers/ATZStyleKit.m
@@ -100,14 +100,12 @@ static NSString *const BUTTON_TITLE_BLOCKED = @"BLOCKED";
     CGContextAddPath(context, clippingPath);
     CGContextClip(context);
 
-    // Text font & style
-    NSFont *font = [NSFont fontWithName:@"HelveticaNeue-Light" size:12];
     NSMutableParagraphStyle* textStyle = NSMutableParagraphStyle.defaultParagraphStyle.mutableCopy;
     textStyle.alignment = NSCenterTextAlignment;
     textStyle.lineBreakMode = NSLineBreakByClipping;
 
     NSDictionary* textFontAttributes = @{
-        NSFontAttributeName:font,
+        NSFontAttributeName:[NSFont fontWithName:@"HelveticaNeue-Light" size:12],
         NSForegroundColorAttributeName:color,
         NSParagraphStyleAttributeName:textStyle,
     };

--- a/Alcatraz/Helpers/ATZStyleKit.m
+++ b/Alcatraz/Helpers/ATZStyleKit.m
@@ -25,6 +25,10 @@
 #import "ATZPlugin.h"
 #import "ATZFillableButton.h"
 
+static NSString *const BUTTON_TITLE_INSTALL = @"INSTALL";
+static NSString *const BUTTON_TITLE_REMOVE = @"REMOVE";
+static NSString *const BUTTON_TITLE_BLOCKED = @"BLOCKED";
+
 @implementation ATZStyleKit
 
 #pragma mark ATZFillableButton styling
@@ -32,18 +36,18 @@
 + (void)updateButton:(ATZFillableButton *)fillableButton forPackageState:(ATZPackage *)package animated:(BOOL)animated {
     if ([package isInstalled]) {
         if ([package isBlacklisted]) {
-            [fillableButton setTitle:@"BLOCKED"];
+            [fillableButton setTitle:BUTTON_TITLE_BLOCKED];
             [fillableButton setButtonStyle:ATZFillableButtonStyleBlocked];
             [fillableButton setFillRatio:0 animated:animated];
         }
         else {
-            [fillableButton setTitle:@"REMOVE"];
+            [fillableButton setTitle:BUTTON_TITLE_REMOVE];
             [fillableButton setButtonStyle:ATZFillableButtonStyleRemove];
             [fillableButton setFillRatio:1 animated:animated];
         }
     }
     else {
-        [fillableButton setTitle:@"INSTALL"];
+        [fillableButton setTitle:BUTTON_TITLE_INSTALL];
         [fillableButton setButtonStyle:ATZFillableButtonStyleInstall];
         [fillableButton setFillRatio:0 animated:animated];
     }

--- a/Alcatraz/Helpers/ATZStyleKit.m
+++ b/Alcatraz/Helpers/ATZStyleKit.m
@@ -26,71 +26,45 @@
 
 @implementation ATZStyleKit
 
-#pragma mark Initialization
-
-+ (void)initialize
-{
-}
-
 #pragma mark Drawing Methods
 
-+ (void)drawFillableButtonWithButtonText: (NSString*)buttonText fillRatio: (CGFloat)fillRatio buttonWidth: (CGFloat)buttonWidth buttonType: (NSString*)buttonType
-{
-    //// General Declarations
-    CGContextRef context = (CGContextRef)NSGraphicsContext.currentContext.graphicsPort;
++ (void)drawFillableButtonWithText:(NSString*)text fillColor:(NSColor *)fillColor backgroundColor:(NSColor *)backgroundColor fillRatio:(float)fillRatio size:(CGSize)size {
+    NSParameterAssert(0.0f <= fillRatio && fillRatio <= 1.0f);
 
-    //// Color Declarations
-    NSColor* buttonColor = [NSColor colorWithCalibratedRed: 0.311 green: 0.699 blue: 0.37 alpha: 1];
-    NSColor* clear = [NSColor clearColor];
-    NSColor* white = [NSColor whiteColor];
-    NSColor* gray = [NSColor colorWithCalibratedRed: 0.378 green: 0.378 blue: 0.378 alpha: 1];
-    NSColor* removeButtonColor = [NSColor colorWithCalibratedRed: 0.845 green: 0.236 blue: 0.362 alpha: 1];
+    CGFloat cornerRadius = 2.0f;
+    CGFloat borderWidth = 1.0f;
+    CGRect bounds = CGRectMake(0, 0, size.width, size.height);
+    bounds = CGRectInset(bounds, borderWidth, borderWidth);
+    bounds = CGRectIntegral(bounds);
+    CGFloat fillWidth = bounds.size.width * fillRatio;
 
-    //// Variable Declarations
-    CGFloat computedFillWidth = fillRatio * buttonWidth * 0.01;
-    CGFloat fillWidth = computedFillWidth < 0 ? 0 : (computedFillWidth > buttonWidth ? buttonWidth : computedFillWidth);
-    NSColor* buttonTextPrimaryColor = [buttonType isEqualToString: @"install"] ? buttonColor : gray;
-    NSColor* buttonTextSecondaryColor = white;
-    NSColor* buttonStrokeColor = [buttonType isEqualToString: @"install"] ? (fillRatio >= 100 ? removeButtonColor : buttonColor) : gray;
-    NSColor* buttonFillColor = fillWidth <= 8 ? clear : (fillRatio >= 100 ? removeButtonColor : buttonStrokeColor);
+    //// Fill drawing
+    CGRect fillRect = bounds;
+    fillRect.size.width = fillWidth;
+    NSBezierPath* fillPath = [NSBezierPath bezierPathWithRoundedRect:fillRect xRadius:cornerRadius yRadius:cornerRadius];
+    [fillColor setFill];
+    [fillPath fill];
 
-    //// borderRect Drawing
-    NSBezierPath* borderRectPath = [NSBezierPath bezierPathWithRoundedRect: NSMakeRect(1, 1, (buttonWidth - 3), 25) xRadius: 2 yRadius: 2];
-    [buttonStrokeColor setStroke];
-    [borderRectPath setLineWidth: 1];
-    [borderRectPath stroke];
-
-
-    //// fillRect Drawing
-    [NSGraphicsContext saveGraphicsState];
-    CGContextTranslateCTM(context, 1, 2);
-
-    NSBezierPath* fillRectPath = [NSBezierPath bezierPathWithRoundedRect: NSMakeRect(0, -1.5, (fillWidth - 3), 25) xRadius: 2 yRadius: 2];
-    [buttonFillColor setFill];
-    [fillRectPath fill];
-
-    [NSGraphicsContext restoreGraphicsState];
-
+    //// Border drawing
+    NSBezierPath* borderPath = [NSBezierPath bezierPathWithRoundedRect:bounds xRadius:cornerRadius yRadius:cornerRadius];
+    [fillColor setStroke];
+    [borderPath setLineWidth:borderWidth];
+    [borderPath stroke];
 
     //// Text Drawing
-    CGFloat textInset = 4;
-    NSRect textRect = NSMakeRect(1, -2, buttonWidth, 20);
-    textRect = NSOffsetRect(textRect, 0, 4);
+    // Drawing the right part of the text with the fill color (eg. green)
+    NSRect primaryColorClippingRect = bounds;
+    primaryColorClippingRect.origin.x += fillWidth;
+    primaryColorClippingRect.size.width -= fillWidth;
+    [self drawText:text withColor:fillColor centeredInRect:bounds clippedToRect:primaryColorClippingRect];
 
-    // Drawing the right part of the text with the primary color (eg. green)
-    NSRect primaryColorClippingRect = textRect;
-    primaryColorClippingRect.origin.x += fillWidth - textInset;
-    primaryColorClippingRect.size.width -= fillWidth - textInset;
-    [self drawText:buttonText withColor:buttonTextPrimaryColor centeredInRect:textRect clippedToRect:primaryColorClippingRect];
-
-    // Drawing the left part of the text with the secondary color (eg. white)
-    NSRect secondaryColorClippingRect = textRect;
-    secondaryColorClippingRect.size.width = fillWidth - textInset;
-    [self drawText:buttonText withColor:buttonTextSecondaryColor centeredInRect:textRect clippedToRect:secondaryColorClippingRect];
+    // Drawing the left part of the text with the background color (eg. white)
+    NSRect secondaryColorClippingRect = bounds;
+    secondaryColorClippingRect.size.width = fillWidth;
+    [self drawText:text withColor:backgroundColor centeredInRect:bounds clippedToRect:secondaryColorClippingRect];
 }
 
-+ (void)drawText:(NSString*)text withColor:(NSColor *)color centeredInRect:(NSRect)rect clippedToRect:(NSRect)clippingRect
-{
++ (void)drawText:(NSString*)text withColor:(NSColor *)color centeredInRect:(NSRect)rect clippedToRect:(NSRect)clippingRect {
     CGContextRef context = (CGContextRef)NSGraphicsContext.currentContext.graphicsPort;
 
     [NSGraphicsContext saveGraphicsState];
@@ -99,16 +73,37 @@
     CGContextAddPath(context, clippingPath);
     CGContextClip(context);
 
+    // Text font & style
+    NSFont *font = [NSFont fontWithName:@"HelveticaNeue-Light" size:12];
     NSMutableParagraphStyle* textStyle = NSMutableParagraphStyle.defaultParagraphStyle.mutableCopy;
     textStyle.alignment = NSCenterTextAlignment;
+    textStyle.lineBreakMode = NSLineBreakByClipping;
 
     NSDictionary* textFontAttributes = @{
-        NSFontAttributeName:[NSFont fontWithName:@"HelveticaNeue-Light" size:12],
+        NSFontAttributeName:font,
         NSForegroundColorAttributeName:color,
-        NSParagraphStyleAttributeName: textStyle
+        NSParagraphStyleAttributeName:textStyle,
     };
 
-    [text drawInRect:rect withAttributes:textFontAttributes];
+    // Center the text vertically
+    // A lot more complicated to get right than what I expected
+    // See http://www.gameaid.org/2012/11/vertically-align-an-nsstring-in-an-nsrect/
+    NSTextStorage *textStorage = [[NSTextStorage alloc] initWithString:text];
+    [textStorage addAttributes:textFontAttributes range:NSMakeRange(0, text.length)];
+
+    NSLayoutManager *layoutManager = [[NSLayoutManager alloc] init];
+    NSTextContainer *textContainer = [[NSTextContainer alloc] initWithContainerSize:rect.size];
+    textContainer.lineFragmentPadding = 0;
+
+    [layoutManager addTextContainer:textContainer];
+    [textStorage addLayoutManager:layoutManager];
+
+    NSRange glyphRange = [layoutManager glyphRangeForTextContainer:textContainer];
+    CGRect textUsedRect = [layoutManager usedRectForTextContainer:textContainer];
+    CGPoint drawingPoint = CGPointMake(rect.origin.x, rect.origin.y + (rect.size.height - textUsedRect.size.height) / 2);
+
+    // Finally draw the text
+    [layoutManager drawGlyphsForGlyphRange:glyphRange atPoint:drawingPoint];
 
     [NSGraphicsContext restoreGraphicsState];
 }

--- a/Alcatraz/Helpers/ATZStyleKit.m
+++ b/Alcatraz/Helpers/ATZStyleKit.m
@@ -22,7 +22,7 @@
 // THE SOFTWARE.
 
 #import "ATZStyleKit.h"
-#import "ATZPackage.h"
+#import "ATZPlugin.h"
 #import "ATZFillableButton.h"
 
 @implementation ATZStyleKit
@@ -31,9 +31,16 @@
 
 + (void)updateButton:(ATZFillableButton *)fillableButton forPackageState:(ATZPackage *)package animated:(BOOL)animated {
     if ([package isInstalled]) {
-        [fillableButton setTitle:@"REMOVE"];
-        [fillableButton setButtonStyle:ATZFillableButtonStyleRemove];
-        [fillableButton setFillRatio:1 animated:animated];
+        if ([package isBlacklisted]) {
+            [fillableButton setTitle:@"BLOCKED"];
+            [fillableButton setButtonStyle:ATZFillableButtonStyleBlocked];
+            [fillableButton setFillRatio:0 animated:animated];
+        }
+        else {
+            [fillableButton setTitle:@"REMOVE"];
+            [fillableButton setButtonStyle:ATZFillableButtonStyleRemove];
+            [fillableButton setFillRatio:1 animated:animated];
+        }
     }
     else {
         [fillableButton setTitle:@"INSTALL"];

--- a/Alcatraz/Helpers/ATZXcodePrefsManager.h
+++ b/Alcatraz/Helpers/ATZXcodePrefsManager.h
@@ -1,0 +1,20 @@
+//
+//  ATZXcodePrefsManager.h
+//  Alcatraz
+//
+//  Created by Guillaume Algis on 14/07/2015.
+//  Copyright (c) 2015 supermar.in. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@class ATZPackage;
+
+@interface ATZXcodePrefsManager : NSObject
+
++ (instancetype)sharedManager;
+
+- (void)whitelistPackage:(ATZPackage *)package completion:(void(^)(NSError *error))completion;
+- (BOOL)isPackageBlacklisted:(ATZPackage *)package;
+
+@end

--- a/Alcatraz/Helpers/ATZXcodePrefsManager.m
+++ b/Alcatraz/Helpers/ATZXcodePrefsManager.m
@@ -1,0 +1,81 @@
+//
+//  ATZXcodePrefsManager.m
+//  Alcatraz
+//
+//  Created by Guillaume Algis on 14/07/2015.
+//  Copyright (c) 2015 supermar.in. All rights reserved.
+//
+
+#import "ATZXcodePrefsManager.h"
+#import "ATZPackage.h"
+#import "ATZInstaller.h"
+
+static NSString *const NON_APPLE_PLUGINS_KEY_FORMAT = @"DVTPlugInManagerNonApplePlugIns-Xcode-%@";
+static NSString *const NON_APPLE_PLUGINS_WHITELISTED_KEY = @"allowed";
+static NSString *const NON_APPLE_PLUGINS_BLACKLISTED_KEY = @"skipped";
+
+@implementation ATZXcodePrefsManager
+
+#pragma mark - Singleton
+
++ (instancetype)sharedManager {
+    static ATZXcodePrefsManager *instance = nil;
+
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        instance = [[self alloc] init];
+    });
+    return instance;
+}
+
+#pragma mark - Public
+
+- (void)whitelistPackage:(ATZPackage *)package completion:(void(^)(NSError *error))completion {
+    NSString *pluginManagerKey = [self xcodeDefaultsNonApplePluginsKey];
+    NSMutableDictionary *nonApplePlugins = [[[NSUserDefaults standardUserDefaults] dictionaryForKey:pluginManagerKey] mutableCopy];
+    NSMutableDictionary *whitelistedPlugins = [nonApplePlugins[NON_APPLE_PLUGINS_WHITELISTED_KEY] mutableCopy];
+    NSMutableDictionary *blacklistedPlugins = [nonApplePlugins[NON_APPLE_PLUGINS_BLACKLISTED_KEY] mutableCopy];
+
+    NSBundle *pluginBundle = [NSBundle bundleWithPath:[package.installer pathForInstalledPackage:package]];
+    NSString *pluginIdentifier = [pluginBundle bundleIdentifier];
+
+    NSDictionary *pluginEntry = blacklistedPlugins[pluginIdentifier];
+    [blacklistedPlugins removeObjectForKey:pluginIdentifier];
+    whitelistedPlugins[pluginIdentifier] = pluginEntry;
+
+    nonApplePlugins[NON_APPLE_PLUGINS_WHITELISTED_KEY] = [whitelistedPlugins copy];
+    nonApplePlugins[NON_APPLE_PLUGINS_BLACKLISTED_KEY] = [blacklistedPlugins copy];
+
+    [[NSUserDefaults standardUserDefaults] setObject:[nonApplePlugins copy] forKey:pluginManagerKey];
+    BOOL synchronizedSuccessfully = [[NSUserDefaults standardUserDefaults] synchronize];
+
+    NSError *error;
+    if (!synchronizedSuccessfully) {
+        error = [NSError errorWithDomain:@"Could not update Xcode's preferences and whitelist plugin" code:666 userInfo:nil];
+    }
+
+    completion(error);
+}
+
+- (BOOL)isPackageBlacklisted:(ATZPackage *)package {
+    if (![package isInstalled]) {
+        return NO;
+    }
+
+    NSString *pluginManagerKey = [self xcodeDefaultsNonApplePluginsKey];
+    NSDictionary *nonApplePlugins = [[NSUserDefaults standardUserDefaults] dictionaryForKey:pluginManagerKey];
+    NSArray *skippedPluginsIdentifiers = [nonApplePlugins[NON_APPLE_PLUGINS_BLACKLISTED_KEY] allKeys];
+
+    NSBundle *pluginBundle = [NSBundle bundleWithPath:[package.installer pathForInstalledPackage:package]];
+
+    return [skippedPluginsIdentifiers containsObject:[pluginBundle bundleIdentifier]];
+}
+
+#pragma mark - Private
+
+- (NSString *)xcodeDefaultsNonApplePluginsKey {
+    NSString *xcodeVersion = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
+    return [NSString stringWithFormat:NON_APPLE_PLUGINS_KEY_FORMAT, xcodeVersion];
+}
+
+@end

--- a/Alcatraz/Installers/ATZInstaller.h
+++ b/Alcatraz/Installers/ATZInstaller.h
@@ -39,9 +39,8 @@ static NSString *const UPDATING_FORMAT = @"Updating %@...";
                                            completion:(void(^)(NSError *error))completion;
 - (void)updatePackage:(ATZPackage *)package progress:(void(^)(NSString *progressMessage, CGFloat progress))progress
                                           completion:(void(^)(NSError *error))completion;
-- (void)removePackage:(ATZPackage *)package
-           completion:(void(^)(NSError *error))completion;
-
+- (void)removePackage:(ATZPackage *)package completion:(void(^)(NSError *error))completion;
+- (void)whitelistPackage:(ATZPackage *)package completion:(void(^)(NSError *error))completion;
 
 - (BOOL)isPackageBlacklisted:(ATZPackage *)package;
 - (BOOL)isPackageInstalled:(ATZPackage *)package;

--- a/Alcatraz/Installers/ATZInstaller.h
+++ b/Alcatraz/Installers/ATZInstaller.h
@@ -40,9 +40,7 @@ static NSString *const UPDATING_FORMAT = @"Updating %@...";
 - (void)updatePackage:(ATZPackage *)package progress:(void(^)(NSString *progressMessage, CGFloat progress))progress
                                           completion:(void(^)(NSError *error))completion;
 - (void)removePackage:(ATZPackage *)package completion:(void(^)(NSError *error))completion;
-- (void)whitelistPackage:(ATZPackage *)package completion:(void(^)(NSError *error))completion;
 
-- (BOOL)isPackageBlacklisted:(ATZPackage *)package;
 - (BOOL)isPackageInstalled:(ATZPackage *)package;
 - (NSString *)pathForDownloadedPackage:(ATZPackage *)package;
 

--- a/Alcatraz/Installers/ATZInstaller.h
+++ b/Alcatraz/Installers/ATZInstaller.h
@@ -43,6 +43,7 @@ static NSString *const UPDATING_FORMAT = @"Updating %@...";
            completion:(void(^)(NSError *error))completion;
 
 
+- (BOOL)isPackageBlacklisted:(ATZPackage *)package;
 - (BOOL)isPackageInstalled:(ATZPackage *)package;
 - (NSString *)pathForDownloadedPackage:(ATZPackage *)package;
 

--- a/Alcatraz/Installers/ATZInstaller.m
+++ b/Alcatraz/Installers/ATZInstaller.m
@@ -117,6 +117,11 @@ const CGFloat ATZFakeInstallProgress = 0.66;
                                    reason:@"Abstract Installer doesn't know how to install" userInfo:nil];
 }
 
+- (void)whitelistPackage:(ATZPackage *)package completion:(void(^)(NSError *error))completion {
+    @throw [NSException exceptionWithName:@"Abstract Installer"
+                                   reason:@"Abstract Installer doesn't know how to whitelist" userInfo:nil];
+}
+
 
 - (NSString *)pathForInstalledPackage:(ATZPackage *)package {
     @throw [NSException exceptionWithName:@"Abstract Installer"

--- a/Alcatraz/Installers/ATZInstaller.m
+++ b/Alcatraz/Installers/ATZInstaller.m
@@ -81,6 +81,10 @@ const CGFloat ATZFakeInstallProgress = 0.66;
     [[NSFileManager sharedManager] removeItemAtPath:[self pathForInstalledPackage:package] completion:completion];
 }
 
+- (BOOL)isPackageBlacklisted:(ATZPackage *)package {
+    return NO;
+}
+
 - (BOOL)isPackageInstalled:(ATZPackage *)package {
     return [[NSFileManager sharedManager] fileExistsAtPath:[self pathForInstalledPackage:package]];
 }

--- a/Alcatraz/Installers/ATZInstaller.m
+++ b/Alcatraz/Installers/ATZInstaller.m
@@ -81,10 +81,6 @@ const CGFloat ATZFakeInstallProgress = 0.66;
     [[NSFileManager sharedManager] removeItemAtPath:[self pathForInstalledPackage:package] completion:completion];
 }
 
-- (BOOL)isPackageBlacklisted:(ATZPackage *)package {
-    return NO;
-}
-
 - (BOOL)isPackageInstalled:(ATZPackage *)package {
     return [[NSFileManager sharedManager] fileExistsAtPath:[self pathForInstalledPackage:package]];
 }
@@ -116,12 +112,6 @@ const CGFloat ATZFakeInstallProgress = 0.66;
     @throw [NSException exceptionWithName:@"Abstract Installer"
                                    reason:@"Abstract Installer doesn't know how to install" userInfo:nil];
 }
-
-- (void)whitelistPackage:(ATZPackage *)package completion:(void(^)(NSError *error))completion {
-    @throw [NSException exceptionWithName:@"Abstract Installer"
-                                   reason:@"Abstract Installer doesn't know how to whitelist" userInfo:nil];
-}
-
 
 - (NSString *)pathForInstalledPackage:(ATZPackage *)package {
     @throw [NSException exceptionWithName:@"Abstract Installer"

--- a/Alcatraz/Installers/ATZPluginInstaller.m
+++ b/Alcatraz/Installers/ATZPluginInstaller.m
@@ -38,10 +38,6 @@ static NSString *const BUILD = @"build";
 static NSString *const XCODEPROJ = @".xcodeproj";
 static NSString *const PROJECT_PBXPROJ = @"project.pbxproj";
 
-static NSString *const NON_APPLE_PLUGINS_KEY_FORMAT = @"DVTPlugInManagerNonApplePlugIns-Xcode-%@";
-static NSString *const NON_APPLE_PLUGINS_WHITELISTED_KEY = @"allowed";
-static NSString *const NON_APPLE_PLUGINS_BLACKLISTED_KEY = @"skipped";
-
 @implementation ATZPluginInstaller
 
 #pragma mark - Abstract
@@ -86,45 +82,6 @@ static NSString *const NON_APPLE_PLUGINS_BLACKLISTED_KEY = @"skipped";
     }
 
     return path;
-}
-
-- (BOOL)isPackageBlacklisted:(ATZPackage *)package {
-    if (![self isPackageInstalled:package]) {
-        return NO;
-    }
-
-    NSString *pluginManagerKey = [self xcodeDefaultsNonApplePluginsKey];
-    NSDictionary *nonApplePlugins = [[NSUserDefaults standardUserDefaults] dictionaryForKey:pluginManagerKey];
-    NSArray *skippedPluginsIdentifiers = [nonApplePlugins[NON_APPLE_PLUGINS_BLACKLISTED_KEY] allKeys];
-
-    NSBundle *pluginBundle = [NSBundle bundleWithPath:[self pathForInstalledPackage:package]];
-}
-
-- (void)whitelistPackage:(ATZPackage *)package completion:(void(^)(NSError *error))completion {
-    NSString *pluginManagerKey = [self xcodeDefaultsNonApplePluginsKey];
-    NSMutableDictionary *nonApplePlugins = [[[NSUserDefaults standardUserDefaults] dictionaryForKey:pluginManagerKey] mutableCopy];
-    NSMutableDictionary *whitelistedPlugins = [nonApplePlugins[NON_APPLE_PLUGINS_WHITELISTED_KEY] mutableCopy];
-    NSMutableDictionary *blacklistedPlugins = [nonApplePlugins[NON_APPLE_PLUGINS_BLACKLISTED_KEY] mutableCopy];
-
-    NSBundle *pluginBundle = [NSBundle bundleWithPath:[self pathForInstalledPackage:package]];
-    NSString *pluginIdentifier = [pluginBundle bundleIdentifier];
-
-    NSDictionary *pluginEntry = blacklistedPlugins[pluginIdentifier];
-    [blacklistedPlugins removeObjectForKey:pluginIdentifier];
-    whitelistedPlugins[pluginIdentifier] = pluginEntry;
-
-    nonApplePlugins[NON_APPLE_PLUGINS_WHITELISTED_KEY] = [whitelistedPlugins copy];
-    nonApplePlugins[NON_APPLE_PLUGINS_BLACKLISTED_KEY] = [blacklistedPlugins copy];
-
-    [[NSUserDefaults standardUserDefaults] setObject:[nonApplePlugins copy] forKey:pluginManagerKey];
-    BOOL synchronizedSuccessfully = [[NSUserDefaults standardUserDefaults] synchronize];
-
-    NSError *error;
-    if (!synchronizedSuccessfully) {
-        error = [NSError errorWithDomain:@"Could not update Xcode's preferences and whitelist plugin" code:666 userInfo:nil];
-    }
-
-    completion(error);
 }
 
 #pragma mark - Hooks
@@ -207,11 +164,6 @@ static NSString *const NON_APPLE_PLUGINS_BLACKLISTED_KEY = @"skipped";
     } else {
         NSLog(@"%@",[NSString stringWithFormat:@"%@ does not implement the pluginDidLoad: method.", plugin.name]);
     }
-}
-
-- (NSString *)xcodeDefaultsNonApplePluginsKey {
-    NSString *xcodeVersion = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
-    return [NSString stringWithFormat:NON_APPLE_PLUGINS_KEY_FORMAT, xcodeVersion];
 }
 
 @end

--- a/Alcatraz/Installers/ATZPluginInstaller.m
+++ b/Alcatraz/Installers/ATZPluginInstaller.m
@@ -38,6 +38,8 @@ static NSString *const BUILD = @"build";
 static NSString *const XCODEPROJ = @".xcodeproj";
 static NSString *const PROJECT_PBXPROJ = @"project.pbxproj";
 
+static NSString *const NON_APPLE_PLUGINS_KEY_FORMAT = @"DVTPlugInManagerNonApplePlugIns-Xcode-%@";
+
 @implementation ATZPluginInstaller
 
 #pragma mark - Abstract
@@ -82,6 +84,19 @@ static NSString *const PROJECT_PBXPROJ = @"project.pbxproj";
     }
 
     return path;
+}
+
+- (BOOL)isPackageBlacklisted:(ATZPackage *)package {
+    if (![self isPackageInstalled:package]) {
+        return NO;
+    }
+
+    NSString *xcodeVersion = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
+    NSString *pluginManagerKey = [NSString stringWithFormat:NON_APPLE_PLUGINS_KEY_FORMAT, xcodeVersion];
+    NSDictionary *nonApplePlugins = [[NSUserDefaults standardUserDefaults] dictionaryForKey:pluginManagerKey];
+    NSArray *skippedPluginsIdentifiers = [nonApplePlugins[@"skipped"] allKeys];
+
+    NSBundle *pluginBundle = [NSBundle bundleWithPath:[self pathForInstalledPackage:package]];
 }
 
 #pragma mark - Hooks

--- a/Alcatraz/Installers/ATZTemplateInstaller.m
+++ b/Alcatraz/Installers/ATZTemplateInstaller.m
@@ -44,7 +44,6 @@
     [self copyTemplatesToXcode:package completion:completion];
 }
 
-
 #pragma mark - Private
 
 - (void)copyTemplatesToXcode:(ATZTemplate *)template completion:(void (^)(NSError *))completion {

--- a/Alcatraz/Packages/ATZPackage.h
+++ b/Alcatraz/Packages/ATZPackage.h
@@ -41,6 +41,7 @@ typedef NS_ENUM(NSUInteger, ATZPackageWebsiteType) {
 @property (strong, nonatomic) NSString *screenshotPath;
 @property (nonatomic, readonly) NSString *website;
 @property (nonatomic, readonly) NSString *extension;
+@property (nonatomic, readonly) BOOL isBlacklisted;
 @property (nonatomic, readonly) BOOL isInstalled;
 @property (nonatomic, assign)   BOOL requiresRestart;
 @property (nonatomic, readonly) ATZPackageWebsiteType websiteType;

--- a/Alcatraz/Packages/ATZPackage.h
+++ b/Alcatraz/Packages/ATZPackage.h
@@ -56,6 +56,8 @@ typedef NS_ENUM(NSUInteger, ATZPackageWebsiteType) {
 
 - (void)removeWithCompletion:(void(^)(NSError *failure))completion;
 
+- (void)whitelistWithCompletion:(void(^)(NSError *failure))completion;
+
 
 #pragma mark - Abstract
 

--- a/Alcatraz/Packages/ATZPackage.m
+++ b/Alcatraz/Packages/ATZPackage.m
@@ -99,6 +99,10 @@
     [[self installer] removePackage:self completion:completion];
 }
 
+- (void)whitelistWithCompletion:(void(^)(NSError *failure))completion {
+    [self.installer whitelistPackage:self completion:completion];
+}
+
 - (ATZInstaller *)installer {
     @throw [NSException exceptionWithName:@"Not Implemented" reason:@"Each package has a different installer!" userInfo:nil];
 }

--- a/Alcatraz/Packages/ATZPackage.m
+++ b/Alcatraz/Packages/ATZPackage.m
@@ -22,6 +22,7 @@
 
 #import "ATZPackage.h"
 #import "ATZInstaller.h"
+#import "ATZXcodePrefsManager.h"
 #import "ATZGit.h"
 
 @implementation ATZPackage
@@ -76,7 +77,7 @@
 #pragma mark - Abstract
 
 - (BOOL)isBlacklisted {
-    return [[self installer] isPackageBlacklisted:self];
+    return [[ATZXcodePrefsManager sharedManager] isPackageBlacklisted:self];
 }
 
 - (BOOL)isInstalled {
@@ -100,7 +101,7 @@
 }
 
 - (void)whitelistWithCompletion:(void(^)(NSError *failure))completion {
-    [self.installer whitelistPackage:self completion:completion];
+    [[ATZXcodePrefsManager sharedManager] whitelistPackage:self completion:completion];
 }
 
 - (ATZInstaller *)installer {

--- a/Alcatraz/Packages/ATZPackage.m
+++ b/Alcatraz/Packages/ATZPackage.m
@@ -73,8 +73,11 @@
     else return self.remotePath;
 }
 
-
 #pragma mark - Abstract
+
+- (BOOL)isBlacklisted {
+    return [[self installer] isPackageBlacklisted:self];
+}
 
 - (BOOL)isInstalled {
     return [[self installer] isPackageInstalled:self];

--- a/Alcatraz/Views/ATZFillableButton.h
+++ b/Alcatraz/Views/ATZFillableButton.h
@@ -21,13 +21,17 @@
 
 #import <Cocoa/Cocoa.h>
 
-extern NSString* const ATZFillableButtonTypeInstall;
-extern NSString* const ATZFillableButtonTypeNormal;
+typedef NS_ENUM(NSUInteger, ATZFillableButtonStyle) {
+    ATZFillableButtonStyleInstall,
+    ATZFillableButtonStyleRemove,
+    ATZFillableButtonStyleBlocked,
+};
 
 @interface ATZFillableButton : NSButton
 
-@property (nonatomic, strong) NSString* buttonBorderStyle;
-@property (nonatomic) float fillRatio;
+@property (nonatomic, assign) ATZFillableButtonStyle buttonStyle;
+@property (nonatomic, assign) float fillRatio;
 
 - (void)setFillRatio:(float)fillRatio animated:(BOOL)animated;
+
 @end

--- a/Alcatraz/Views/ATZFillableButton.m
+++ b/Alcatraz/Views/ATZFillableButton.m
@@ -23,8 +23,12 @@
 #import "ATZFillableButton.h"
 #import "ATZStyleKit.h"
 
-NSString* const ATZFillableButtonTypeInstall = @"install";
-NSString* const ATZFillableButtonTypeNormal = @"normal";
+@interface ATZFillableButton ()
+
+@property (nonatomic, strong) NSColor *backgroundColor;
+@property (nonatomic, strong) NSColor *fillColor;
+
+@end
 
 @implementation ATZFillableButton
 
@@ -37,14 +41,13 @@ NSString* const ATZFillableButtonTypeNormal = @"normal";
 }
 
 - (void)drawRect:(NSRect)dirtyRect {
-    [ATZStyleKit drawFillableButtonWithButtonText:self.title
-                                        fillRatio:self.fillRatio
-                                      buttonWidth:CGRectGetWidth(self.bounds)
-                                       buttonType:self.buttonBorderStyle?:ATZFillableButtonTypeNormal];
+    [ATZStyleKit drawFillableButtonWithText:self.title fillColor:self.fillColor backgroundColor:self.backgroundColor fillRatio:self.fillRatio size:self.bounds.size];
 }
 
-- (void)setButtonBorderStyle:(NSString *)buttonBorderStyle {
-    _buttonBorderStyle = buttonBorderStyle;
+- (void)setButtonStyle:(ATZFillableButtonStyle)buttonStyle {
+    _buttonStyle = buttonStyle;
+
+    [self updateButtonColorsMatchingStyle:buttonStyle];
     [self setNeedsDisplay];
 }
 
@@ -58,6 +61,27 @@ NSString* const ATZFillableButtonTypeNormal = @"normal";
         self.animator.fillRatio = fillRatio;
     } else {
         self.fillRatio = fillRatio;
+    }
+}
+
+- (void)updateButtonColorsMatchingStyle:(ATZFillableButtonStyle)buttonStyle {
+    NSColor *installGreen = [NSColor colorWithCalibratedRed:0.311 green:0.699 blue:0.37 alpha:1];
+    NSColor *removeRed = [NSColor colorWithCalibratedRed:0.845 green:0.236 blue:0.362 alpha:1];
+    NSColor *blockedOrange = [NSColor colorWithCalibratedRed:0.869 green:0.413 blue:0.106 alpha:1];
+
+    switch (buttonStyle) {
+        case ATZFillableButtonStyleInstall:
+            self.fillColor = installGreen;
+            self.backgroundColor = [NSColor whiteColor];
+            break;
+        case ATZFillableButtonStyleRemove:
+            self.fillColor = removeRed;
+            self.backgroundColor = [NSColor whiteColor];
+            break;
+        case ATZFillableButtonStyleBlocked:
+            self.fillColor = blockedOrange;
+            self.backgroundColor = [NSColor whiteColor];
+            break;
     }
 }
 

--- a/Alcatraz/Views/ATZFillableButton.m
+++ b/Alcatraz/Views/ATZFillableButton.m
@@ -72,17 +72,15 @@
     switch (buttonStyle) {
         case ATZFillableButtonStyleInstall:
             self.fillColor = installGreen;
-            self.backgroundColor = [NSColor whiteColor];
             break;
         case ATZFillableButtonStyleRemove:
             self.fillColor = removeRed;
-            self.backgroundColor = [NSColor whiteColor];
             break;
         case ATZFillableButtonStyleBlocked:
             self.fillColor = blockedOrange;
-            self.backgroundColor = [NSColor whiteColor];
             break;
     }
+    self.backgroundColor = [NSColor whiteColor];
 }
 
 @end


### PR DESCRIPTION
 Fixes #283.

Basically this:
- Displays blocked plugins in the list with a special orange "BLOCKED" button;
- Allows the user to whitelist (unblock) plugins by clicking this button;
- Add a filter option to show only blocked plugins in the segmented control, with a count of the blocked plugins (the filter option is only shown if you have blocked plugins on your machine).

Comments and code review are obviously very welcome :)

![blocked plugins in the list](https://cloud.githubusercontent.com/assets/1041337/8388639/c1f7aa52-1c64-11e5-8702-1b6d00cfaeb8.png)
