### PR TITLE
Remove Alcatraz from Xcode skipped plugins list on install

### DIFF
--- a/Scripts/install.sh
+++ b/Scripts/install.sh
@@ -7,14 +7,19 @@ PLUGINS_DIR="${HOME}/Library/Application Support/Developer/Shared/Xcode/Plug-ins
 XCODE_VERSION="$(xcrun xcodebuild -version | head -n1 | awk '{ print $2 }')"
 PLIST_PLUGINS_KEY="DVTPlugInManagerNonApplePlugIns-Xcode-${XCODE_VERSION}"
 BUNDLE_ID="com.mneorr.Alcatraz"
-TMP_FILE="/tmp/${BUNDLE_ID}.xcode-defaults"
+TMP_FILE="$(mktemp -t ${BUNDLE_ID})"
 
 # Remove Alcatraz from Xcode's skipped plugins list if needed
 defaults read -app Xcode "$PLIST_PLUGINS_KEY" > "$TMP_FILE"
 /usr/libexec/PlistBuddy -c "delete skipped:$BUNDLE_ID" "$TMP_FILE" > /dev/null 2>&1 && {
-	pgrep Xcode > /dev/null && { echo 'An instance of Xcode is currently running. Please close Xcode before installing Alcatraz.'; exit 1; }
-	defaults write -app Xcode "$PLIST_PLUGINS_KEY" "$(< $TMP_FILE)"
-	echo 'Alcatraz was removed from Xcode'\''s skipped plugins list. Next time you start Xcode select "Load Bundle" when prompted.'
+    pgrep Xcode > /dev/null && {
+        echo 'An instance of Xcode is currently running.' \
+             'Please close Xcode before installing Alcatraz.'
+        exit 1
+    }
+    defaults write -app Xcode "$PLIST_PLUGINS_KEY" "$(cat "$TMP_FILE")"
+    echo 'Alcatraz was removed from Xcode'\''s skipped plugins list.' \
+         'Next time you start Xcode select "Load Bundle" when prompted.'
 }
 rm "$TMP_FILE"
 
@@ -22,5 +27,6 @@ mkdir -p "${PLUGINS_DIR}"
 curl -L $DOWNLOAD_URI | tar xvz -C "${PLUGINS_DIR}"
 
 # the 1 is not a typo!
-echo "Alcatraz successfully installed!!1!🍻   Please restart your Xcode ($XCODE_VERSION)."
+echo 'Alcatraz successfully installed!!1!🍻 ' \
+     "Please restart your Xcode ($XCODE_VERSION)."
 

--- a/Scripts/install.sh
+++ b/Scripts/install.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -euo pipefail
+
 DOWNLOAD_URI=https://github.com/alcatraz/Alcatraz/releases/download/1.1.13/Alcatraz.tar.gz
 PLUGINS_DIR="${HOME}/Library/Application Support/Developer/Shared/Xcode/Plug-ins"
 

--- a/Scripts/install.sh
+++ b/Scripts/install.sh
@@ -22,5 +22,5 @@ mkdir -p "${PLUGINS_DIR}"
 curl -L $DOWNLOAD_URI | tar xvz -C "${PLUGINS_DIR}"
 
 # the 1 is not a typo!
-echo "Alcatraz successfully installed!!1!🍻   Please restart your Xcode."
+echo "Alcatraz successfully installed!!1!🍻   Please restart your Xcode ($XCODE_VERSION)."
 

--- a/Scripts/install.sh
+++ b/Scripts/install.sh
@@ -4,6 +4,19 @@ set -euo pipefail
 
 DOWNLOAD_URI=https://github.com/alcatraz/Alcatraz/releases/download/1.1.13/Alcatraz.tar.gz
 PLUGINS_DIR="${HOME}/Library/Application Support/Developer/Shared/Xcode/Plug-ins"
+XCODE_VERSION="$(xcrun xcodebuild -version | head -n1 | awk '{ print $2 }')"
+PLIST_PLUGINS_KEY="DVTPlugInManagerNonApplePlugIns-Xcode-${XCODE_VERSION}"
+BUNDLE_ID="com.mneorr.Alcatraz"
+TMP_FILE="/tmp/${BUNDLE_ID}.xcode-defaults"
+
+# Remove Alcatraz from Xcode's skipped plugins list if needed
+defaults read -app Xcode "$PLIST_PLUGINS_KEY" > "$TMP_FILE"
+/usr/libexec/PlistBuddy -c "delete skipped:$BUNDLE_ID" "$TMP_FILE" > /dev/null 2>&1 && {
+	pgrep Xcode > /dev/null && { echo 'An instance of Xcode is currently running. Please close Xcode before installing Alcatraz.'; exit 1; }
+	defaults write -app Xcode "$PLIST_PLUGINS_KEY" "$(< $TMP_FILE)"
+	echo 'Alcatraz was removed from Xcode'\''s skipped plugins list. Next time you start Xcode select "Load Bundle" when prompted.'
+}
+rm "$TMP_FILE"
 
 mkdir -p "${PLUGINS_DIR}"
 curl -L $DOWNLOAD_URI | tar xvz -C "${PLUGINS_DIR}"


### PR DESCRIPTION
Related to #281, #282, #303 and probably a whole bunch of other issues.

This is very similar #282, but just removes Alcatraz from the skipped plugins list instead of un-blocking everything.
I also took the chance to add ["strict flags"](http://redsymbol.net/articles/unofficial-bash-strict-mode/) to the sh script, and echoing the current selected version of Xcode after install.