### PR TITLE
[WIP] Feature/#332 Alcatraz CLI

### DIFF
--- a/Alcatraz.xcodeproj/project.pbxproj
+++ b/Alcatraz.xcodeproj/project.pbxproj
@@ -57,8 +57,21 @@
 		8AD5249F174102F9008B451F /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 8AD524A2174102F9008B451F /* Localizable.strings */; };
 		8ADC22341A2AD5B800DB7BCA /* ATZPreviewImageButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 8ADC22331A2AD5B800DB7BCA /* ATZPreviewImageButton.m */; };
 		8AF670C919C2DE8A00E1C168 /* ATZSegmentedControl.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AF670C819C2DE8A00E1C168 /* ATZSegmentedControl.m */; };
+		C92245F51BA02E90004E7321 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C92245F41BA02E90004E7321 /* main.swift */; };
 		F0DF961E1B40416400DF68CC /* ATZSegmentedCell.m in Sources */ = {isa = PBXBuildFile; fileRef = F0DF961D1B40416400DF68CC /* ATZSegmentedCell.m */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		C92245F01BA02E8F004E7321 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = /usr/share/man/man1/;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		079C9E02183D8BB8009F5A17 /* link_icon.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = link_icon.png; sourceTree = "<group>"; };
@@ -144,6 +157,8 @@
 		8ADC22331A2AD5B800DB7BCA /* ATZPreviewImageButton.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ATZPreviewImageButton.m; path = Views/ATZPreviewImageButton.m; sourceTree = "<group>"; };
 		8AF670C719C2DE8A00E1C168 /* ATZSegmentedControl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ATZSegmentedControl.h; path = Views/ATZSegmentedControl.h; sourceTree = "<group>"; };
 		8AF670C819C2DE8A00E1C168 /* ATZSegmentedControl.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ATZSegmentedControl.m; path = Views/ATZSegmentedControl.m; sourceTree = "<group>"; };
+		C92245F21BA02E8F004E7321 /* AlcatrazCLI */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = AlcatrazCLI; sourceTree = BUILT_PRODUCTS_DIR; };
+		C92245F41BA02E90004E7321 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		F0DF961C1B40416300DF68CC /* ATZSegmentedCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ATZSegmentedCell.h; sourceTree = "<group>"; };
 		F0DF961D1B40416400DF68CC /* ATZSegmentedCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ATZSegmentedCell.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -157,6 +172,13 @@
 				0C7AF650186B4E890064EE7B /* QuartzCore.framework in Frameworks */,
 				890A4B43171F031300AFE577 /* AppKit.framework in Frameworks */,
 				890A4B45171F031300AFE577 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C92245EF1BA02E8F004E7321 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -183,6 +205,7 @@
 			isa = PBXGroup;
 			children = (
 				890A4B46171F031300AFE577 /* Alcatraz */,
+				C92245F31BA02E90004E7321 /* AlcatrazCLI */,
 				890A4B41171F031300AFE577 /* Frameworks */,
 				890A4B40171F031300AFE577 /* Products */,
 			);
@@ -192,6 +215,7 @@
 			isa = PBXGroup;
 			children = (
 				890A4B3F171F031300AFE577 /* Alcatraz.xcplugin */,
+				C92245F21BA02E8F004E7321 /* AlcatrazCLI */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -358,6 +382,14 @@
 			name = en.lproj;
 			sourceTree = "<group>";
 		};
+		C92245F31BA02E90004E7321 /* AlcatrazCLI */ = {
+			isa = PBXGroup;
+			children = (
+				C92245F41BA02E90004E7321 /* main.swift */,
+			);
+			path = AlcatrazCLI;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -378,6 +410,23 @@
 			productReference = 890A4B3F171F031300AFE577 /* Alcatraz.xcplugin */;
 			productType = "com.apple.product-type.bundle";
 		};
+		C92245F11BA02E8F004E7321 /* AlcatrazCLI */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C92245F81BA02E90004E7321 /* Build configuration list for PBXNativeTarget "AlcatrazCLI" */;
+			buildPhases = (
+				C92245EE1BA02E8F004E7321 /* Sources */,
+				C92245EF1BA02E8F004E7321 /* Frameworks */,
+				C92245F01BA02E8F004E7321 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = AlcatrazCLI;
+			productName = AlcatrazCLI;
+			productReference = C92245F21BA02E8F004E7321 /* AlcatrazCLI */;
+			productType = "com.apple.product-type.tool";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -385,8 +434,14 @@
 			isa = PBXProject;
 			attributes = {
 				CLASSPREFIX = ATZ;
+				LastSwiftUpdateCheck = 0700;
 				LastUpgradeCheck = 0500;
 				ORGANIZATIONNAME = supermar.in;
+				TargetAttributes = {
+					C92245F11BA02E8F004E7321 = {
+						CreatedOnToolsVersion = 7.0;
+					};
+				};
 			};
 			buildConfigurationList = 890A4B3A171F031300AFE577 /* Build configuration list for PBXProject "Alcatraz" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -401,6 +456,7 @@
 			projectRoot = "";
 			targets = (
 				890A4B3E171F031300AFE577 /* Alcatraz */,
+				C92245F11BA02E8F004E7321 /* AlcatrazCLI */,
 			);
 		};
 /* End PBXProject section */
@@ -467,6 +523,14 @@
 				894714E817302F63003CDDA7 /* ATZInstaller.m in Sources */,
 				897F7899173FC54C006C43E5 /* ATZAlcatrazPackage.m in Sources */,
 				8A4C621A19C2D6F1003580BD /* ATZFilterBarView.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C92245EE1BA02E8F004E7321 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C92245F51BA02E90004E7321 /* main.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -554,6 +618,7 @@
 		890A4B53171F031300AFE577 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
@@ -563,9 +628,12 @@
 				GCC_PREFIX_HEADER = "Alcatraz/Alcatraz-Prefix.pch";
 				INFOPLIST_FILE = "Alcatraz/Alcatraz-Info.plist";
 				INSTALL_PATH = "/Library/Application Support/Developer/Shared/Xcode/Plug-ins";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
+				SWIFT_OBJC_BRIDGING_HEADER = "Alcatraz/Alcatraz-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				WRAPPER_EXTENSION = xcplugin;
 			};
 			name = Debug;
@@ -573,6 +641,7 @@
 		890A4B54171F031300AFE577 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
@@ -582,10 +651,58 @@
 				GCC_PREFIX_HEADER = "Alcatraz/Alcatraz-Prefix.pch";
 				INFOPLIST_FILE = "Alcatraz/Alcatraz-Info.plist";
 				INSTALL_PATH = "/Library/Application Support/Developer/Shared/Xcode/Plug-ins";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 				WRAPPER_EXTENSION = xcplugin;
+			};
+			name = Release;
+		};
+		C92245F61BA02E90004E7321 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		C92245F71BA02E90004E7321 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				COPY_PHASE_STRIP = NO;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;
 		};
@@ -606,6 +723,15 @@
 			buildConfigurations = (
 				890A4B53171F031300AFE577 /* Debug */,
 				890A4B54171F031300AFE577 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		C92245F81BA02E90004E7321 /* Build configuration list for PBXNativeTarget "AlcatrazCLI" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C92245F61BA02E90004E7321 /* Debug */,
+				C92245F71BA02E90004E7321 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Alcatraz.xcodeproj/project.pbxproj
+++ b/Alcatraz.xcodeproj/project.pbxproj
@@ -58,6 +58,27 @@
 		8ADC22341A2AD5B800DB7BCA /* ATZPreviewImageButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 8ADC22331A2AD5B800DB7BCA /* ATZPreviewImageButton.m */; };
 		8AF670C919C2DE8A00E1C168 /* ATZSegmentedControl.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AF670C819C2DE8A00E1C168 /* ATZSegmentedControl.m */; };
 		C92245F51BA02E90004E7321 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C92245F41BA02E90004E7321 /* main.swift */; };
+		C92245FC1BA02FF6004E7321 /* ATZAlcatrazPackage.m in Sources */ = {isa = PBXBuildFile; fileRef = 897F7898173FC54C006C43E5 /* ATZAlcatrazPackage.m */; };
+		C92245FD1BA02FFA004E7321 /* ATZPackage.m in Sources */ = {isa = PBXBuildFile; fileRef = 8917D9EC1726B4EE00F0B2D2 /* ATZPackage.m */; };
+		C92245FF1BA03098004E7321 /* ATZStyleKit.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AA0F57C19C2225A00556AAF /* ATZStyleKit.m */; };
+		C92246011BA03098004E7321 /* ATZDownloader.m in Sources */ = {isa = PBXBuildFile; fileRef = 8917DA131726B63B00F0B2D2 /* ATZDownloader.m */; };
+		C92246031BA03098004E7321 /* ATZGit.m in Sources */ = {isa = PBXBuildFile; fileRef = 8917DA151726B63B00F0B2D2 /* ATZGit.m */; };
+		C92246051BA03098004E7321 /* ATZShell.m in Sources */ = {isa = PBXBuildFile; fileRef = 8917DA171726B63B00F0B2D2 /* ATZShell.m */; };
+		C92246071BA03098004E7321 /* ATZPBXProjParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 89B4F2BD172FF5AC001FD2E3 /* ATZPBXProjParser.m */; };
+		C92246091BA030BD004E7321 /* ATZInstaller.m in Sources */ = {isa = PBXBuildFile; fileRef = 894714E717302F63003CDDA7 /* ATZInstaller.m */; };
+		C922460B1BA030BD004E7321 /* ATZColorSchemeInstaller.m in Sources */ = {isa = PBXBuildFile; fileRef = 8917D9FB1726B53000F0B2D2 /* ATZColorSchemeInstaller.m */; };
+		C922460D1BA030BD004E7321 /* ATZFileTemplateInstaller.m in Sources */ = {isa = PBXBuildFile; fileRef = 8917D9FD1726B53000F0B2D2 /* ATZFileTemplateInstaller.m */; };
+		C922460F1BA030BD004E7321 /* ATZPluginInstaller.m in Sources */ = {isa = PBXBuildFile; fileRef = 8917DA001726B53000F0B2D2 /* ATZPluginInstaller.m */; };
+		C92246111BA030BD004E7321 /* ATZProjectTemplateInstaller.m in Sources */ = {isa = PBXBuildFile; fileRef = 8917DA021726B53000F0B2D2 /* ATZProjectTemplateInstaller.m */; };
+		C92246131BA030BD004E7321 /* ATZTemplateInstaller.m in Sources */ = {isa = PBXBuildFile; fileRef = 8917DA041726B53000F0B2D2 /* ATZTemplateInstaller.m */; };
+		C92246151BA030BD004E7321 /* ATZPackageFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = 8917DA0F1726B5BA00F0B2D2 /* ATZPackageFactory.m */; };
+		C92246171BA030BD004E7321 /* ATZColorScheme.m in Sources */ = {isa = PBXBuildFile; fileRef = 8917D9E81726B4EE00F0B2D2 /* ATZColorScheme.m */; };
+		C92246191BA030BD004E7321 /* ATZFileTemplate.m in Sources */ = {isa = PBXBuildFile; fileRef = 8917D9EA1726B4EE00F0B2D2 /* ATZFileTemplate.m */; };
+		C922461C1BA030BD004E7321 /* ATZPlugin.m in Sources */ = {isa = PBXBuildFile; fileRef = 8917D9EE1726B4EE00F0B2D2 /* ATZPlugin.m */; };
+		C922461E1BA030BD004E7321 /* ATZProjectTemplate.m in Sources */ = {isa = PBXBuildFile; fileRef = 8917D9F01726B4EE00F0B2D2 /* ATZProjectTemplate.m */; };
+		C92246201BA030BD004E7321 /* ATZTemplate.m in Sources */ = {isa = PBXBuildFile; fileRef = 8917D9F21726B4EE00F0B2D2 /* ATZTemplate.m */; };
+		C92246221BA0317A004E7321 /* NSFileManager+Alcatraz.m in Sources */ = {isa = PBXBuildFile; fileRef = 8917DA0C1726B57B00F0B2D2 /* NSFileManager+Alcatraz.m */; };
+		C96A24431BA97FF600578CCD /* Installer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C96A24421BA97FF600578CCD /* Installer.swift */; settings = {ASSET_TAGS = (); }; };
 		F0DF961E1B40416400DF68CC /* ATZSegmentedCell.m in Sources */ = {isa = PBXBuildFile; fileRef = F0DF961D1B40416400DF68CC /* ATZSegmentedCell.m */; };
 /* End PBXBuildFile section */
 
@@ -159,6 +180,8 @@
 		8AF670C819C2DE8A00E1C168 /* ATZSegmentedControl.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ATZSegmentedControl.m; path = Views/ATZSegmentedControl.m; sourceTree = "<group>"; };
 		C92245F21BA02E8F004E7321 /* AlcatrazCLI */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = AlcatrazCLI; sourceTree = BUILT_PRODUCTS_DIR; };
 		C92245F41BA02E90004E7321 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
+		C92245F91BA02F48004E7321 /* AlcatrazCLI-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "AlcatrazCLI-Bridging-Header.h"; sourceTree = "<group>"; };
+		C96A24421BA97FF600578CCD /* Installer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Installer.swift; sourceTree = "<group>"; };
 		F0DF961C1B40416300DF68CC /* ATZSegmentedCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ATZSegmentedCell.h; sourceTree = "<group>"; };
 		F0DF961D1B40416400DF68CC /* ATZSegmentedCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ATZSegmentedCell.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -386,6 +409,8 @@
 			isa = PBXGroup;
 			children = (
 				C92245F41BA02E90004E7321 /* main.swift */,
+				C96A24421BA97FF600578CCD /* Installer.swift */,
+				C92245F91BA02F48004E7321 /* AlcatrazCLI-Bridging-Header.h */,
 			);
 			path = AlcatrazCLI;
 			sourceTree = "<group>";
@@ -530,7 +555,28 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C92246091BA030BD004E7321 /* ATZInstaller.m in Sources */,
+				C922460B1BA030BD004E7321 /* ATZColorSchemeInstaller.m in Sources */,
+				C922460D1BA030BD004E7321 /* ATZFileTemplateInstaller.m in Sources */,
+				C922460F1BA030BD004E7321 /* ATZPluginInstaller.m in Sources */,
+				C92246111BA030BD004E7321 /* ATZProjectTemplateInstaller.m in Sources */,
+				C92246131BA030BD004E7321 /* ATZTemplateInstaller.m in Sources */,
+				C92246151BA030BD004E7321 /* ATZPackageFactory.m in Sources */,
+				C92246171BA030BD004E7321 /* ATZColorScheme.m in Sources */,
+				C92246191BA030BD004E7321 /* ATZFileTemplate.m in Sources */,
+				C922461C1BA030BD004E7321 /* ATZPlugin.m in Sources */,
+				C922461E1BA030BD004E7321 /* ATZProjectTemplate.m in Sources */,
+				C92246201BA030BD004E7321 /* ATZTemplate.m in Sources */,
+				C92245FF1BA03098004E7321 /* ATZStyleKit.m in Sources */,
+				C92246011BA03098004E7321 /* ATZDownloader.m in Sources */,
+				C96A24431BA97FF600578CCD /* Installer.swift in Sources */,
+				C92246031BA03098004E7321 /* ATZGit.m in Sources */,
+				C92246051BA03098004E7321 /* ATZShell.m in Sources */,
+				C92246071BA03098004E7321 /* ATZPBXProjParser.m in Sources */,
+				C92245FC1BA02FF6004E7321 /* ATZAlcatrazPackage.m in Sources */,
+				C92246221BA0317A004E7321 /* NSFileManager+Alcatraz.m in Sources */,
 				C92245F51BA02E90004E7321 /* main.swift in Sources */,
+				C92245FD1BA02FFA004E7321 /* ATZPackage.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -655,6 +701,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
+				SWIFT_OBJC_BRIDGING_HEADER = "Alcatraz/Alcatraz-Bridging-Header.h";
 				WRAPPER_EXTENSION = xcplugin;
 			};
 			name = Release;
@@ -679,6 +726,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "AlcatrazCLI/AlcatrazCLI-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
 			name = Debug;
@@ -703,6 +751,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "AlcatrazCLI/AlcatrazCLI-Bridging-Header.h";
 			};
 			name = Release;
 		};

--- a/Alcatraz.xcodeproj/xcshareddata/xcschemes/AlcatrazCLI.xcscheme
+++ b/Alcatraz.xcodeproj/xcshareddata/xcschemes/AlcatrazCLI.xcscheme
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0700"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C92245F11BA02E8F004E7321"
+               BuildableName = "AlcatrazCLI"
+               BlueprintName = "AlcatrazCLI"
+               ReferencedContainer = "container:Alcatraz.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C92245F11BA02E8F004E7321"
+            BuildableName = "AlcatrazCLI"
+            BlueprintName = "AlcatrazCLI"
+            ReferencedContainer = "container:Alcatraz.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C92245F11BA02E8F004E7321"
+            BuildableName = "AlcatrazCLI"
+            BlueprintName = "AlcatrazCLI"
+            ReferencedContainer = "container:Alcatraz.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "install dupa i kupa"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C92245F11BA02E8F004E7321"
+            BuildableName = "AlcatrazCLI"
+            BlueprintName = "AlcatrazCLI"
+            ReferencedContainer = "container:Alcatraz.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Alcatraz/Helpers/ATZDownloader.m
+++ b/Alcatraz/Helpers/ATZDownloader.m
@@ -139,7 +139,7 @@ didCompleteWithError:(NSError *)error {
     
     _urlSession = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration]
                                                 delegate:self
-                                           delegateQueue:[NSOperationQueue mainQueue]];
+                                           delegateQueue:[NSOperationQueue currentQueue]];
     return _urlSession;
 }
 

--- a/Alcatraz/Helpers/ATZShell.m
+++ b/Alcatraz/Helpers/ATZShell.m
@@ -71,7 +71,7 @@
 - (void)setUpTerminationHandlerForTask:(NSTask *)task completion:(void(^)(NSString *taskOutput, NSError *error))completion {
     [task setTerminationHandler:^(NSTask *task) {
         
-        [[NSOperationQueue mainQueue] addOperationWithBlock:^{
+//        [[NSOperationQueue currentQueue] addOperationWithBlock:^{
             NSString* output = [[NSString alloc] initWithData:self.taskOutput encoding:NSUTF8StringEncoding];
             
             if (task.terminationStatus == 0) {
@@ -80,7 +80,7 @@
                 NSString* reason = [NSString stringWithFormat:@"Task exited with status %d", task.terminationStatus];
                 completion(output, [NSError errorWithDomain:reason code:666 userInfo:@{ NSLocalizedDescriptionKey: reason }]);
             }
-        }];
+//        }];
         
         [task.standardOutput fileHandleForReading].readabilityHandler = nil;
         [task.standardError fileHandleForReading].readabilityHandler = nil;

--- a/AlcatrazCLI/AlcatrazCLI-Bridging-Header.h
+++ b/AlcatrazCLI/AlcatrazCLI-Bridging-Header.h
@@ -1,0 +1,12 @@
+//
+//  AlcatrazCLI-Bridging-Header.h
+//  Alcatraz
+//
+//  Created by Wojciech Czekalski on 09.09.2015.
+//  Copyright © 2015 supermar.in. All rights reserved.
+//
+
+#import "ATZAlcatrazPackage.h"
+#import "ATZDownloader.h"
+#import "ATZPackageFactory.h"
+#import "ATZInstaller.h"

--- a/AlcatrazCLI/Installer.swift
+++ b/AlcatrazCLI/Installer.swift
@@ -1,0 +1,34 @@
+//
+//  Installer.swift
+//  Alcatraz
+//
+//  Created by Wojciech Czekalski on 16.09.2015.
+//  Copyright © 2015 supermar.in. All rights reserved.
+//
+
+import Foundation
+
+func installPackage(package: ATZPackage) -> ResultType { // this is quick and dirty
+    
+    var result = ResultType.Error(description: "undefined")
+    
+    let semaphore = dispatch_semaphore_create(0)
+    
+    let queue = NSOperationQueue()
+    
+    queue.addOperationWithBlock { () -> Void in
+        
+        package.installer().installPackage(package, progress: {(_,_) -> Void in }, completion: { (error: NSError!) -> Void in
+            if let error = error {
+                result = .Error(description: error.localizedDescription)
+            } else {
+                result = .Finish(description: nil)
+            }
+            dispatch_semaphore_signal(semaphore)
+        })
+    }
+    
+    dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER)
+    
+    return result
+}

--- a/AlcatrazCLI/main.swift
+++ b/AlcatrazCLI/main.swift
@@ -1,0 +1,10 @@
+//
+//  main.swift
+//  AlcatrazCLI
+//
+//  Created by Wojciech Czekalski on 09.09.2015.
+//  Copyright © 2015 supermar.in. All rights reserved.
+//
+
+import Foundation
+

--- a/AlcatrazCLI/main.swift
+++ b/AlcatrazCLI/main.swift
@@ -8,3 +8,133 @@
 
 import Foundation
 
+enum ResultType {
+    case Continue(f:() -> ResultType)
+    case Error(description: String)
+    case Finish(description: String?)
+    
+    func resolve() -> String? {
+        switch self {
+        case .Error(let description):
+            return description
+        case .Continue(let f):
+            return f().resolve()
+        case .Finish(let d):
+            return d
+        }
+    }
+}
+
+enum Command: String {
+    case help, update, install, remove
+    
+    func parse(args:[String]) -> ResultType {
+        switch self {
+        case .help:
+            guard args.count == 0 else {
+                return .Error(description: errorString(args))
+            }
+            return .Continue(f: helpString)
+        case .update:
+            return .Finish(description: nil)
+        case .install:
+            return validateInstall(args)
+        case .remove:
+            return .Finish(description: nil)
+        }
+    }
+    
+    var description: String {
+        get {
+            switch self {
+            case .update:
+                return "updates Alcatraz and Alcatraz CLI"
+            case .remove:
+                return ""
+            case .help:
+                return ""
+            case .install:
+                return "installs a package. Usage: 'alcatraz install [package-name]'"
+            }
+        }
+    }
+    
+    static let commands: [Command] = [.update, .install, .remove]
+}
+
+func validateInstall(args: [String]) -> ResultType {
+    guard args.count == 1 else {
+        return ResultType.Error(description: errorString(args))
+    }
+    return .Continue(f: install(args.first!))
+}
+
+func install(packageName: String) -> () -> ResultType {
+    return {
+        if let package = packageForName(packageName) {
+            return installPackage(package)
+        } else {
+            return .Error(description: "Could not fetch \(packageName)")
+        }
+    }
+}
+
+func packageForName(name: String) -> ATZPackage? {
+    
+    let URL = NSURL(string: ATZDownloader.packageRepoPath())
+
+    if let URL = URL, data = NSData(contentsOfURL: URL) {
+        
+        do {
+            let dict = try NSJSONSerialization.JSONObjectWithData(data, options: NSJSONReadingOptions(rawValue: 0)) as! NSDictionary as Dictionary
+            
+            let packages = ATZPackageFactory.createPackagesFromDicts(dict["packages"]! as! [NSObject : AnyObject]) as! Array<ATZPackage>
+            return packages.filter({ (package: ATZPackage) -> Bool in
+                    return package.name.isEqual(name)
+                }).first
+            
+        } catch {
+            
+        }
+    }
+    return nil
+}
+
+func helpString() -> ResultType {
+    
+    let introText = "\nAlcatraz is an amazing Xcode package manager\n\n"
+    let commandsCaption = "   The available commands are:\n"
+   
+    let formatCommand = { (command: Command) -> String in
+        return "      " + "\(command.rawValue) - \(command.description)" + "\n"
+    }
+    
+    let helpText = introText + commandsCaption + Command.commands.map(formatCommand).joinWithSeparator("");
+    
+    return .Finish(description: helpText)
+}
+
+func errorString(args: [String]) -> String {
+    let argsString = args.joinWithSeparator(" ")
+    let fullCommandString = "alcatraz \(argsString)".stringByTrimmingCharactersInSet(NSCharacterSet.whitespaceAndNewlineCharacterSet())
+    
+    return "\"\(fullCommandString)\" is not a valid command. See 'alcatraz help' for more info"
+}
+
+func run(var args: [String]) {
+    
+    args.removeFirst() // Removes executable path from arguments
+    
+    guard let command = Command(rawValue: args.first!) else {
+        print(errorString(args))
+        return
+    }
+    
+    args.removeFirst()
+    
+    if let retString = command.parse(args).resolve() {
+        print(retString)
+    }
+}
+
+run(Process.arguments)


### PR DESCRIPTION
**This is work in progress**

I created this pull request because I stumbled upon a big blocker when implementing this. Namely the existing networking code is structured in a way that it _cannot_ be run synchronously.

When I started implementing this I stumbled upon this problem. I solved it temporairly with a brute force approach ([here](https://github.com/supermarin/Alcatraz/commit/ba2edb4e8ddf68bd8da97b45250f9f2703b45300) and [here](https://github.com/supermarin/Alcatraz/compare/master...wczekalski:feature/%23332-Alcatraz-CLI?expand=1#diff-bedeb80e1311bbb6f8276ad37ea41c01R11)) but it's not the way to go, obviously.

Please note that the modifications in Alcatraz classes were unavoidable. We would wait for the downloader to finish on the main thread and its internal `NSURLSession` would wait to dispatch delegate calls on the same thread. There is a similar issue with `ATZShell`. It dispatches the completion handler of internal `NSTask` to `mainQueue` which waits for completion of the installation task and it results in a deadlock.

I can see just one solution; refactor/rewrite of those classes to allow more control. Possibly by more control over threads where things are exectued

What would you suggest to do? What do you think having better knowledge about the codebase?
@jurre @supermarin 
