### PR TITLE
Added correct detection of installed ideplugins

### DIFF
--- a/Alcatraz/Helpers/ATZPBXProjParser.m
+++ b/Alcatraz/Helpers/ATZPBXProjParser.m
@@ -22,7 +22,8 @@
 
 #import "ATZPbxprojParser.h"
 
-static NSString *const PLUGIN_NAME_REGEX = @"(\\w[\\w\\s-]*\\w.xcplugin)";
+// Xcode plugin extension can be xcplugin or ideplugin
+static NSString *const PLUGIN_NAME_REGEX = @"(\\w[\\w\\s-]*\\w.(xc|ide)plugin\\s)";
 
 @implementation ATZPbxprojParser
 
@@ -37,10 +38,9 @@ static NSString *const PLUGIN_NAME_REGEX = @"(\\w[\\w\\s-]*\\w.xcplugin)";
     if (error) return nil;
     
     NSTextCheckingResult *result = [regex firstMatchInString:pbxproj options:0 range:NSMakeRange(0, pbxproj.length - 1)];
-    NSString *pluginName = result ? [pbxproj substringWithRange:result.range] : nil;
-    NSString *nameWithoutExtension = [pluginName substringWithRange:NSMakeRange(0, pluginName.length - 9)];
-    
-    return nameWithoutExtension;
+    NSString *pluginName = result ? [[pbxproj substringWithRange:result.range] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] : nil;
+
+    return pluginName;
 }
 
 @end

--- a/Alcatraz/Installers/ATZPluginInstaller.m
+++ b/Alcatraz/Installers/ATZPluginInstaller.m
@@ -28,6 +28,7 @@
 #import "ATZPBXProjParser.h"
 
 static NSString *const INSTALLED_PLUGINS_RELATIVE_PATH = @"Library/Application Support/Developer/Shared/Xcode/Plug-ins";
+static NSString *const INSTALLED_IDEPLUGINS_RELATIVE_PATH = @"Library/Developer/Xcode/Plug-ins";
 static NSString *const DOWNLOADED_PLUGINS_RELATIVE_PATH = @"Plug-ins";
 
 static NSString *const XCODE_BUILD = @"/usr/bin/xcodebuild";
@@ -65,10 +66,16 @@ static NSString *const PROJECT_PBXPROJ = @"project.pbxproj";
 // This is a temporary support for installs in /tmp.
 - (NSString *)pathForInstalledPackage:(ATZPackage *)package {
     NSString *pluginsInstallPath = [NSHomeDirectory() stringByAppendingPathComponent:INSTALLED_PLUGINS_RELATIVE_PATH];
-    NSString *pluginInstallName = [self installNameFromPbxproj:package] ?: package.name;
+    NSString *pluginInstallName = [self installNameFromPbxproj:package] ?: [package.name stringByAppendingString:package.extension];
 
-    return [[pluginsInstallPath stringByAppendingPathComponent:pluginInstallName]
-                                       stringByAppendingString:package.extension];
+    // Packages can be installed in multiple places:
+    // ~/Library/Application Support/Developer/Shared/Xcode/Plug-ins (where most xcplugins go)
+    // ~/Library/Developer/Xcode/Plug-ins (where ideplugins go)
+    if ([[pluginInstallName pathExtension] isEqualToString:@"ideplugin"]) {
+        pluginsInstallPath = [NSHomeDirectory() stringByAppendingPathComponent:INSTALLED_IDEPLUGINS_RELATIVE_PATH];
+    }
+
+    return [pluginsInstallPath stringByAppendingPathComponent:pluginInstallName];
 }
 
 

--- a/Alcatraz/Installers/ATZPluginInstaller.m
+++ b/Alcatraz/Installers/ATZPluginInstaller.m
@@ -65,19 +65,24 @@ static NSString *const PROJECT_PBXPROJ = @"project.pbxproj";
 
 // This is a temporary support for installs in /tmp.
 - (NSString *)pathForInstalledPackage:(ATZPackage *)package {
-    NSString *pluginsInstallPath = [NSHomeDirectory() stringByAppendingPathComponent:INSTALLED_PLUGINS_RELATIVE_PATH];
     NSString *pluginInstallName = [self installNameFromPbxproj:package] ?: [package.name stringByAppendingString:package.extension];
-
-    // Packages can be installed in multiple places:
-    // ~/Library/Application Support/Developer/Shared/Xcode/Plug-ins (where most xcplugins go)
-    // ~/Library/Developer/Xcode/Plug-ins (where ideplugins go)
-    if ([[pluginInstallName pathExtension] isEqualToString:@"ideplugin"]) {
-        pluginsInstallPath = [NSHomeDirectory() stringByAppendingPathComponent:INSTALLED_IDEPLUGINS_RELATIVE_PATH];
-    }
+    NSString *pluginsInstallPath = [self pathForPluginsWithExtension:[pluginInstallName pathExtension]];
 
     return [pluginsInstallPath stringByAppendingPathComponent:pluginInstallName];
 }
 
+- (NSString *)pathForPluginsWithExtension:(NSString *)extension
+{
+    NSString *path;
+
+    if ([extension isEqualToString:@"ideplugin"]) {
+        path = [NSHomeDirectory() stringByAppendingPathComponent:INSTALLED_IDEPLUGINS_RELATIVE_PATH];
+    } else {
+        path = [NSHomeDirectory() stringByAppendingPathComponent:INSTALLED_PLUGINS_RELATIVE_PATH];
+    }
+
+    return path;
+}
 
 #pragma mark - Hooks
 // Note: this is an early alpha implementation. It needs some love


### PR DESCRIPTION
Xcode has multiple types of plugin prefixes. Most plugins are xcplugins and can be installed in `~/Library/Application Support/Developer/Shared/Xcode/Plug-ins`, but ideplugins have to be installed in `~/Library/Developer/Xcode/Plug-ins`. [KSImageNamed](https://github.com/ksuther/KSImageNamed-Xcode) switched from being an xcplugin to an ideplugin, so Alcatraz no longer shows it as installed.

`pathForInstalledPackage:` will now detect if it's dealing with an ideplugin that is installed and change the path to the correct one.