### PR TITLE
Subscribe to Xcode launch notification synchronously

### DIFF
--- a/Alcatraz/Alcatraz.m
+++ b/Alcatraz/Alcatraz.m
@@ -52,24 +52,22 @@ static Alcatraz *sharedPlugin;
 - (id)initWithBundle:(NSBundle *)plugin {
     if (self = [super init]) {
         self.bundle = plugin;
-        [[NSOperationQueue mainQueue] addOperationWithBlock:^{
-
-                [[NSNotificationCenter defaultCenter] addObserver:self
-                                                         selector:@selector(xcodeDidFinishLaunching:)
-                                                             name:NSApplicationDidFinishLaunchingNotification
-    object:nil];
-        }];
+        [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(xcodeDidFinishLaunching:)
+                                                     name:NSApplicationDidFinishLaunchingNotification
+                                                   object:nil];
         [self updateAlcatraz];
     }
     return self;
 }
 
-- (void) xcodeDidFinishLaunching: (NSNotification *) notification {
-    [self createMenuItem];
-	
+- (void)xcodeDidFinishLaunching: (NSNotification *) notification {
     [[NSNotificationCenter defaultCenter] removeObserver:self
                                                     name:NSApplicationDidFinishLaunchingNotification
                                                   object:nil];
+    [[NSOperationQueue mainQueue] addOperationWithBlock:^{
+        [self createMenuItem];
+    }];
 }
 
 #pragma mark - Private


### PR DESCRIPTION
The plugin itself always loads as can be noted in the console, but the menu item would intermittently fail to appear.

There seems to be a (common) edge case where the subscription to the notification would be deferred until after the notification is fired. This change fixes it by subscribing immediately upon initialization and
then deferring the menu item creation block instead as may be needed.

Fixes #381, #380, #379