### PR TITLE
Fix install script when no plugin was ever installed in Xcode

### DIFF
--- a/Scripts/install.sh
+++ b/Scripts/install.sh
@@ -10,18 +10,19 @@ BUNDLE_ID="com.mneorr.Alcatraz"
 TMP_FILE="$(mktemp -t ${BUNDLE_ID})"
 
 # Remove Alcatraz from Xcode's skipped plugins list if needed
-defaults read -app Xcode "$PLIST_PLUGINS_KEY" > "$TMP_FILE"
-/usr/libexec/PlistBuddy -c "delete skipped:$BUNDLE_ID" "$TMP_FILE" > /dev/null 2>&1 && {
-    pgrep Xcode > /dev/null && {
-        echo 'An instance of Xcode is currently running.' \
-             'Please close Xcode before installing Alcatraz.'
-        exit 1
+defaults read -app Xcode "$PLIST_PLUGINS_KEY" > "$TMP_FILE" && {
+    /usr/libexec/PlistBuddy -c "delete skipped:$BUNDLE_ID" "$TMP_FILE" > /dev/null 2>&1 && {
+	pgrep Xcode > /dev/null && {
+            echo 'An instance of Xcode is currently running.' \
+		 'Please close Xcode before installing Alcatraz.'
+            exit 1
+	}
+	defaults write -app Xcode "$PLIST_PLUGINS_KEY" "$(cat "$TMP_FILE")"
+	echo 'Alcatraz was removed from Xcode'\''s skipped plugins list.' \
+             'Next time you start Xcode select "Load Bundle" when prompted.'
     }
-    defaults write -app Xcode "$PLIST_PLUGINS_KEY" "$(cat "$TMP_FILE")"
-    echo 'Alcatraz was removed from Xcode'\''s skipped plugins list.' \
-         'Next time you start Xcode select "Load Bundle" when prompted.'
 }
-rm "$TMP_FILE"
+rm -f "$TMP_FILE"
 
 mkdir -p "${PLUGINS_DIR}"
 curl -L $DOWNLOAD_URI | tar xvz -C "${PLUGINS_DIR}"


### PR DESCRIPTION
Fix https://github.com/alcatraz/Alcatraz/issues/392 #394 

If Xcode never loaded any plugin, the `DVTPlugInManagerNonApplePlugIns-Xcode-$xcode_version` does not exist, and the script halted on the line 
```
defaults read -app Xcode "$PLIST_PLUGINS_KEY" > "$TMP_FILE"
```

We now check the return code of `default read` before continuing.

Sorry about that :/