### PR TITLE
Use absolute path for mktemp

### DIFF
--- a/Scripts/install.sh
+++ b/Scripts/install.sh
@@ -7,7 +7,7 @@ PLUGINS_DIR="${HOME}/Library/Application Support/Developer/Shared/Xcode/Plug-ins
 XCODE_VERSION="$(xcrun xcodebuild -version | head -n1 | awk '{ print $2 }')"
 PLIST_PLUGINS_KEY="DVTPlugInManagerNonApplePlugIns-Xcode-${XCODE_VERSION}"
 BUNDLE_ID="com.mneorr.Alcatraz"
-TMP_FILE="$(mktemp -t ${BUNDLE_ID})"
+TMP_FILE="$(/usr/bin/mktemp -t ${BUNDLE_ID})"
 
 # Remove Alcatraz from Xcode's skipped plugins list if needed
 defaults read -app Xcode "$PLIST_PLUGINS_KEY" > "$TMP_FILE" && {


### PR DESCRIPTION
Fix #403.

This prevents the GNU `mktemp` to be used if the user installed the `coreutils` package on their machine with brew.