### PR TITLE
Remove unused import

### DIFF
--- a/Alcatraz/Packages/ATZPackage.m
+++ b/Alcatraz/Packages/ATZPackage.m
@@ -23,7 +23,6 @@
 #import "ATZPackage.h"
 #import "ATZInstaller.h"
 #import "ATZGit.h"
-#import "Alcatraz.h"
 
 @implementation ATZPackage
 @dynamic isInstalled, type, website, extension;


### PR DESCRIPTION
Removing this makes it possible to compile the business logic parts of Alcatraz without AppKit.