### PR TITLE
Copy blocks before storing them in the dictionary

### DIFF
--- a/Alcatraz/Helpers/ATZDownloader.m
+++ b/Alcatraz/Helpers/ATZDownloader.m
@@ -65,9 +65,9 @@ static NSString *const COMPLETION = @"completion";
 
     NSMutableDictionary* callbacks = [[NSMutableDictionary alloc] initWithCapacity:2];
     if (completion)
-        callbacks[COMPLETION] = completion;
+        callbacks[COMPLETION] = Block_copy(completion);
     if (progress)
-        callbacks[PROGRESS] = progress;
+        callbacks[PROGRESS] = Block_copy(progress);
 
     self.callbacks[task] = callbacks;
 


### PR DESCRIPTION
Seems that the :moon: is aligned correctly for this to work inside Xcode, but when trying to use it outside it's :boom: time.