### PR TITLE
[ATZGit] Check possible git executable paths

### DIFF
--- a/Alcatraz/Helpers/ATZGit.h
+++ b/Alcatraz/Helpers/ATZGit.h
@@ -22,7 +22,6 @@
 
 #import <Foundation/Foundation.h>
 
-static NSString *const GIT = @"/usr/bin/git";
 static NSString *const IGNORE_PUSH_CONFIG = @"-c push.default=matching";
 static NSString *const CLONE = @"clone";
 static NSString *const FETCH = @"fetch";


### PR DESCRIPTION
This expands the check for command line tools to include `/usr/local` as well as `/usr`.

Fixes #406, #137, #152 on fresh installations of El Capitan and Yosemite.