### PR TITLE
Make install script work if GNU mktemp is present.

### DIFF
--- a/Scripts/install.sh
+++ b/Scripts/install.sh
@@ -7,7 +7,7 @@ PLUGINS_DIR="${HOME}/Library/Application Support/Developer/Shared/Xcode/Plug-ins
 XCODE_VERSION="$(xcrun xcodebuild -version | head -n1 | awk '{ print $2 }')"
 PLIST_PLUGINS_KEY="DVTPlugInManagerNonApplePlugIns-Xcode-${XCODE_VERSION}"
 BUNDLE_ID="com.mneorr.Alcatraz"
-TMP_FILE="$(mktemp -t ${BUNDLE_ID})"
+TMP_FILE="$(mktemp -t ${BUNDLE_ID}.XXX)"
 
 # Remove Alcatraz from Xcode's skipped plugins list if needed
 defaults read -app Xcode "$PLIST_PLUGINS_KEY" > "$TMP_FILE" && {


### PR DESCRIPTION
Useful if user is using GNU tools from brew/coreutils. Still works if mktemp is standard system BSD version.

Otherwise GNU mktemp complains with `mktemp: too few X's in template ‘com.mneorr.Alcatraz’` and install script fails.