### PR TITLE
Fix install script's defaults read command

### DIFF
--- a/Scripts/install.sh
+++ b/Scripts/install.sh
@@ -13,13 +13,13 @@ TMP_FILE="$(mktemp -t ${BUNDLE_ID})"
 if defaults read com.apple.dt.Xcode "$PLIST_PLUGINS_KEY" > "$TMP_FILE"; then
     # We read the prefs successfully, delete Alcatraz from the skipped list if needed
     /usr/libexec/PlistBuddy -c "delete skipped:$BUNDLE_ID" "$TMP_FILE" > /dev/null 2>&1 && {
-	pgrep Xcode > /dev/null && {
+        pgrep Xcode > /dev/null && {
             echo 'An instance of Xcode is currently running.' \
-		 'Please close Xcode before installing Alcatraz.'
+                 'Please close Xcode before installing Alcatraz.'
             exit 1
-	}
-	defaults write com.apple.dt.Xcode "$PLIST_PLUGINS_KEY" "$(cat "$TMP_FILE")"
-	echo 'Alcatraz was removed from Xcode'\''s skipped plugins list.' \
+        }
+        defaults write com.apple.dt.Xcode "$PLIST_PLUGINS_KEY" "$(cat "$TMP_FILE")"
+        echo 'Alcatraz was removed from Xcode'\''s skipped plugins list.' \
              'Next time you start Xcode select "Load Bundle" when prompted.'
     }
 else

--- a/Scripts/install.sh
+++ b/Scripts/install.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -euo pipefail
 
@@ -10,7 +10,8 @@ BUNDLE_ID="com.mneorr.Alcatraz"
 TMP_FILE="$(mktemp -t ${BUNDLE_ID})"
 
 # Remove Alcatraz from Xcode's skipped plugins list if needed
-defaults read com.apple.dt.Xcode "$PLIST_PLUGINS_KEY" > "$TMP_FILE" && {
+if defaults read com.apple.dt.Xcode "$PLIST_PLUGINS_KEY" > "$TMP_FILE"; then
+    # We read the prefs successfully, delete Alcatraz from the skipped list if needed
     /usr/libexec/PlistBuddy -c "delete skipped:$BUNDLE_ID" "$TMP_FILE" > /dev/null 2>&1 && {
 	pgrep Xcode > /dev/null && {
             echo 'An instance of Xcode is currently running.' \
@@ -21,9 +22,18 @@ defaults read com.apple.dt.Xcode "$PLIST_PLUGINS_KEY" > "$TMP_FILE" && {
 	echo 'Alcatraz was removed from Xcode'\''s skipped plugins list.' \
              'Next time you start Xcode select "Load Bundle" when prompted.'
     }
-}
+else
+    # Could not read the prefs. Filter known warnings, and exit for any other.
+    KNOWN_WARNING="The domain/default pair of \(.+, $PLIST_PLUGINS_KEY\) does not exist"
+
+    # tr: For some mysterious reason, some `defaults` errors are outputed on two lines.
+    # grep: -v returns 1 when output is empty (ie. we filtered the known warning)
+    # so we exit on 0, which means an unknown error occured.
+    tr -d '\n' < "$TMP_FILE" | egrep -v "$KNOWN_WARNING" && exit 1
+fi
 rm -f "$TMP_FILE"
 
+# Download and install Alcatraz
 mkdir -p "${PLUGINS_DIR}"
 curl -L $DOWNLOAD_URI | tar xvz -C "${PLUGINS_DIR}"
 

--- a/Scripts/install.sh
+++ b/Scripts/install.sh
@@ -10,14 +10,14 @@ BUNDLE_ID="com.mneorr.Alcatraz"
 TMP_FILE="$(mktemp -t ${BUNDLE_ID})"
 
 # Remove Alcatraz from Xcode's skipped plugins list if needed
-defaults read -app Xcode "$PLIST_PLUGINS_KEY" > "$TMP_FILE" && {
+defaults read com.apple.dt.Xcode "$PLIST_PLUGINS_KEY" > "$TMP_FILE" && {
     /usr/libexec/PlistBuddy -c "delete skipped:$BUNDLE_ID" "$TMP_FILE" > /dev/null 2>&1 && {
 	pgrep Xcode > /dev/null && {
             echo 'An instance of Xcode is currently running.' \
 		 'Please close Xcode before installing Alcatraz.'
             exit 1
 	}
-	defaults write -app Xcode "$PLIST_PLUGINS_KEY" "$(cat "$TMP_FILE")"
+	defaults write com.apple.dt.Xcode "$PLIST_PLUGINS_KEY" "$(cat "$TMP_FILE")"
 	echo 'Alcatraz was removed from Xcode'\''s skipped plugins list.' \
              'Next time you start Xcode select "Load Bundle" when prompted.'
     }


### PR DESCRIPTION
This adresses two issues:

It silences the warning 

> The domain/default pair of (com.apple.dt.Xcode, DVTPlugInManagerNonApplePlugIns-Xcode-7.2) does not exist

already identified in #393. Hiding this error is fine, as it will only appear when the user never installed a plugin before.
The problem is by using `2> /dev/null` we're effectively silencing all other errors which might occur. If you have any idea how to prevent this, I'll amend the commit.

--------------

It uses `xcode-select` to know where to look for the Xcode app, instead of assuming `/Applications/Xcode.app`. This fixes the error

> Couldn't find an application named "Xcode" defaults unchanged

brought up by @drduan in #419.
I'm not very satisfied with the `sed` bit to trim out the `/Contents/Developer` part of the path returned by `xcode-select`. So again, any input welcome.
