### PR TITLE
Redirect stderr to the temp file used in the install script.

### DIFF
--- a/Scripts/install.sh
+++ b/Scripts/install.sh
@@ -10,7 +10,7 @@ BUNDLE_ID="com.mneorr.Alcatraz"
 TMP_FILE="$(mktemp -t ${BUNDLE_ID})"
 
 # Remove Alcatraz from Xcode's skipped plugins list if needed
-if defaults read com.apple.dt.Xcode "$PLIST_PLUGINS_KEY" > "$TMP_FILE"; then
+if defaults read com.apple.dt.Xcode "$PLIST_PLUGINS_KEY" &> "$TMP_FILE"; then
     # We read the prefs successfully, delete Alcatraz from the skipped list if needed
     /usr/libexec/PlistBuddy -c "delete skipped:$BUNDLE_ID" "$TMP_FILE" > /dev/null 2>&1 && {
         pgrep Xcode > /dev/null && {


### PR DESCRIPTION
Hi,

if stderr is not redirected to the tmp file the output the script tries to match in the else clause will never be there.