### PR TITLE
Fix a name parsing issue if the plugin name includes any '.' character

### DIFF
--- a/Alcatraz/Helpers/ATZPBXProjParser.m
+++ b/Alcatraz/Helpers/ATZPBXProjParser.m
@@ -23,7 +23,7 @@
 #import "ATZPbxprojParser.h"
 
 // Xcode plugin extension can be xcplugin or ideplugin
-static NSString *const PLUGIN_NAME_REGEX = @"(\\w[\\w\\s-]*\\w.(xc|ide)plugin\\s)";
+static NSString *const PLUGIN_NAME_REGEX = @"(\\w[\\w\\s\\.-]*\\w.(xc|ide)plugin\\s)";
 
 @implementation ATZPbxprojParser
 


### PR DESCRIPTION
If any plugin name includes "." character such like "R.swift", the installation process will be interrupt at 100%.
Because the name parsing error causes loading bundle failed