### PR TITLE
Import and Export snapshots

### DIFF
--- a/Alcatraz/ATZPluginWindowController.xib
+++ b/Alcatraz/ATZPluginWindowController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="9531"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10116"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="ATZPluginWindowController">
@@ -23,7 +23,7 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES" unifiedTitleAndToolbar="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="196" y="240" width="545" height="449"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="877"/>
             <view key="contentView" id="EiT-Mj-1SZ">
                 <rect key="frame" x="0.0" y="0.0" width="545" height="449"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -181,12 +181,12 @@
                         <size key="minSize" width="24" height="20"/>
                         <size key="maxSize" width="35" height="39"/>
                         <popUpButton key="view" id="YLN-Se-Z4c">
-                            <rect key="frame" x="12" y="14" width="30" height="28"/>
+                            <rect key="frame" x="10" y="14" width="30" height="28"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                             <constraints>
                                 <constraint firstAttribute="width" constant="30" id="u6i-O7-Ddv"/>
                             </constraints>
-                            <popUpButtonCell key="cell" type="roundTextured" bezelStyle="texturedRounded" imagePosition="below" alignment="center" lineBreakMode="truncatingTail" borderStyle="border" imageScaling="proportionallyDown" inset="2" pullsDown="YES" arrowPosition="noArrow" preferredEdge="maxY" altersStateOfSelectedItem="NO" id="GAy-JH-6Fr">
+                            <popUpButtonCell key="cell" type="roundTextured" bezelStyle="texturedRounded" imagePosition="below" alignment="center" lineBreakMode="truncatingTail" borderStyle="border" imageScaling="proportionallyDown" inset="2" pullsDown="YES" arrowPosition="noArrow" preferredEdge="maxY" altersStateOfSelectedItem="NO" selectedItem="iCw-Se-V3J" id="GAy-JH-6Fr">
                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                 <font key="font" metaFont="menu"/>
                                 <menu key="menu" showsStateColumn="NO" id="gCj-Sg-VLj">
@@ -209,6 +209,18 @@
                                                 <action selector="updatePackageRepoPath:" target="-2" id="Cp9-H4-4ZG"/>
                                             </connections>
                                         </menuItem>
+                                        <menuItem title="Export Plugins Snapshot..." id="iCw-Se-V3J">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="exportPluginsSnapshot:" target="-2" id="CRZ-bw-dPp"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Import Plugins Snapshot..." id="xsP-D2-o5w">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="importPluginsSnapshot:" target="-2" id="vrn-gi-3mP"/>
+                                            </connections>
+                                        </menuItem>
                                     </items>
                                 </menu>
                             </popUpButtonCell>
@@ -228,7 +240,7 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES" resizable="YES" utility="YES" HUD="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="139" y="81" width="276" height="378"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="877"/>
             <view key="contentView" id="WQe-dv-pdE">
                 <rect key="frame" x="0.0" y="0.0" width="276" height="378"/>
                 <autoresizingMask key="autoresizingMask"/>

--- a/Alcatraz/Packages/ATZPackage.h
+++ b/Alcatraz/Packages/ATZPackage.h
@@ -31,7 +31,7 @@ typedef NS_ENUM(NSUInteger, ATZPackageWebsiteType) {
     ATZPackageWebsiteTypeOtherGit,
 };
 
-@interface ATZPackage : NSObject
+@interface ATZPackage : NSObject <NSCoding>
 
 @property (strong, nonatomic) NSString *name;
 @property (strong, nonatomic) NSString *summary;

--- a/Alcatraz/Packages/ATZPackage.m
+++ b/Alcatraz/Packages/ATZPackage.m
@@ -112,4 +112,27 @@
     @throw [NSException exceptionWithName:@"Not Implemented" reason:@"Each package has a different extension!" userInfo:nil];
 }
 
+#pragma mark - NSCoding
+
+- (instancetype)initWithCoder:(NSCoder *)aDecoder {
+    if (self = [super init]) {
+        self.name = [aDecoder decodeObjectForKey:@"name"];
+        self.summary = [aDecoder decodeObjectForKey:@"summary"];
+        self.remotePath = [aDecoder decodeObjectForKey:@"remotePath"];
+        self.revision = [aDecoder decodeObjectForKey:@"revision"];
+        self.screenshotPath = [aDecoder decodeObjectForKey:@"screenshotPath"];
+        self.requiresRestart = [aDecoder decodeBoolForKey:@"requiresRestart"];
+    }
+    return self;
+}
+
+- (void)encodeWithCoder:(NSCoder *)aCoder {
+    [aCoder encodeObject:self.name forKey:@"name"];
+    [aCoder encodeObject:self.summary forKey:@"summary"];
+    [aCoder encodeObject:self.remotePath forKey:@"remotePath"];
+    [aCoder encodeObject:self.revision forKey:@"revision"];
+    [aCoder encodeObject:self.screenshotPath forKey:@"screenshotPath"];
+    [aCoder encodeBool:self.requiresRestart forKey:@"requiresRestart"];
+}
+
 @end

--- a/Alcatraz/Views/ATZPackageListTableCellView.xib
+++ b/Alcatraz/Views/ATZPackageListTableCellView.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="6250" systemVersion="14B25" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="6250"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10116"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="ATZPluginWindowController"/>

--- a/Alcatraz/en.lproj/Localizable.strings
+++ b/Alcatraz/en.lproj/Localizable.strings
@@ -15,3 +15,7 @@ Command Line Tools are available for installation in the Downloads section of Pr
 "change-path.title" = "Change Package Repo Path";
 "actions.cancel" = "Cancel";
 "actions.save" = "Save";
+"actions.import" = "Import";
+
+"export-snapshot.message" = "Enter the local directory to save the Alcatraz Plugins snapshot file";
+"import-snapshot.message" = "Enter the local directory in which the \"alcatraz_snapshot_file\" is located";


### PR DESCRIPTION
Add buttons to allow alcatraz to save and restore snapshots, this way teams can share their plugins with each other using files. 

This pull request has lots of User interface and code organization problems in my opinion, but the idea is to offer the feature so you can see if it makes sense for your development flow like it makes to mine. If so, I plan on improving the interface of the import and export features based on your feedback.

Best regards.