### PR TITLE
Fix the Options menu UI

### DIFF
--- a/Alcatraz/ATZPluginWindowController.xib
+++ b/Alcatraz/ATZPluginWindowController.xib
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
-        <deployment identifier="macosx"/>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10116"/>
     </dependencies>
     <objects>
@@ -176,37 +175,34 @@
                             </connections>
                         </searchField>
                     </toolbarItem>
-                    <toolbarItem implicitItemIdentifier="0E874535-2646-4349-9596-0C449229E817" label="Options" paletteLabel="Options" image="NSActionTemplate" id="Glg-dB-iSd">
+                    <toolbarItem implicitItemIdentifier="70CAB597-64B8-4DF6-8FF2-2CA2FE2B693D" label="Options" paletteLabel="Options" image="NSActionTemplate" id="3yj-6F-IVu">
                         <nil key="toolTip"/>
-                        <size key="minSize" width="24" height="20"/>
-                        <size key="maxSize" width="35" height="39"/>
-                        <popUpButton key="view" id="YLN-Se-Z4c">
-                            <rect key="frame" x="12" y="14" width="30" height="28"/>
+                        <size key="minSize" width="40" height="24"/>
+                        <size key="maxSize" width="40" height="26"/>
+                        <popUpButton key="view" verticalHuggingPriority="750" id="nOd-hy-BMA">
+                            <rect key="frame" x="5" y="14" width="40" height="26"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                            <constraints>
-                                <constraint firstAttribute="width" constant="30" id="u6i-O7-Ddv"/>
-                            </constraints>
-                            <popUpButtonCell key="cell" type="roundTextured" bezelStyle="texturedRounded" imagePosition="below" alignment="center" lineBreakMode="truncatingTail" borderStyle="border" imageScaling="proportionallyDown" inset="2" pullsDown="YES" arrowPosition="noArrow" preferredEdge="maxY" altersStateOfSelectedItem="NO" id="GAy-JH-6Fr">
+                            <popUpButtonCell key="cell" type="roundTextured" bezelStyle="texturedRounded" imagePosition="left" alignment="center" lineBreakMode="truncatingTail" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" pullsDown="YES" id="XPC-Wj-xZq">
                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                 <font key="font" metaFont="menu"/>
-                                <menu key="menu" showsStateColumn="NO" id="gCj-Sg-VLj">
+                                <menu key="menu" id="52b-Ei-k7f">
                                     <items>
-                                        <menuItem image="NSActionTemplate" hidden="YES" id="Mki-6q-Srm"/>
-                                        <menuItem title="Reload Packages" id="FEX-wb-X1U">
+                                        <menuItem state="on" image="NSActionTemplate" hidden="YES" id="vB7-GN-5IN"/>
+                                        <menuItem title="Reload Packages" id="e04-3U-hR5">
                                             <connections>
-                                                <action selector="reloadPackages:" target="-2" id="CE0-pW-r7C"/>
+                                                <action selector="reloadPackages:" target="-2" id="zmd-mi-Rcp"/>
                                             </connections>
                                         </menuItem>
-                                        <menuItem isSeparatorItem="YES" id="vFc-SV-EtA"/>
-                                        <menuItem title="Load Default Repository" id="bPi-Qr-GWZ">
+                                        <menuItem isSeparatorItem="YES" id="VoE-5R-IVf"/>
+                                        <menuItem title="Load Default Repository" id="mJy-b9-aDJ">
                                             <modifierMask key="keyEquivalentModifierMask"/>
                                             <connections>
-                                                <action selector="resetPackageRepoPath:" target="-2" id="k1i-Nk-qOH"/>
+                                                <action selector="resetPackageRepoPath:" target="-2" id="pyp-NY-pMz"/>
                                             </connections>
                                         </menuItem>
-                                        <menuItem title="Load Custom Repository..." id="VFq-69-wpd">
+                                        <menuItem title="Load Custom Repository..." id="SR2-lA-ckQ">
                                             <connections>
-                                                <action selector="updatePackageRepoPath:" target="-2" id="Cp9-H4-4ZG"/>
+                                                <action selector="updatePackageRepoPath:" target="-2" id="GKe-hE-JDF"/>
                                             </connections>
                                         </menuItem>
                                     </items>
@@ -217,9 +213,10 @@
                 </allowedToolbarItems>
                 <defaultToolbarItems>
                     <toolbarItem reference="8Xt-Wm-M1g"/>
+                    <toolbarItem reference="WiE-jh-Iy2"/>
                     <toolbarItem reference="Xrf-3e-xgb"/>
                     <toolbarItem reference="8Xt-Wm-M1g"/>
-                    <toolbarItem reference="Glg-dB-iSd"/>
+                    <toolbarItem reference="3yj-6F-IVu"/>
                 </defaultToolbarItems>
             </toolbar>
             <point key="canvasLocation" x="290.5" y="360.5"/>

--- a/Alcatraz/ATZPluginWindowController.xib
+++ b/Alcatraz/ATZPluginWindowController.xib
@@ -12,7 +12,7 @@
                 <outlet property="previewPanel" destination="4vQ-3a-fNb" id="3Ez-xU-2v3"/>
                 <outlet property="searchField" destination="UNr-70-Qql" id="pQP-eA-7N3"/>
                 <outlet property="tableView" destination="Xmj-hd-CPE" id="AV4-2C-87K"/>
-                <outlet property="versionTextField" destination="hsV-nN-jHO" id="sOR-F4-Ibr"/>
+                <outlet property="versionMenuItem" destination="ZsI-Jz-bMQ" id="6NX-eb-4rv"/>
                 <outlet property="window" destination="QvC-M9-y7g" id="2B8-Td-gLY"/>
             </connections>
         </customObject>
@@ -57,21 +57,11 @@
                                     <action selector="segmentedControlPressed:" target="-2" id="dQL-wu-Ruf"/>
                                 </connections>
                             </segmentedControl>
-                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="hsV-nN-jHO">
-                                <rect key="frame" x="502" y="11" width="31" height="15"/>
-                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="Or1-bZ-rS2">
-                                    <font key="font" size="11" name="HelveticaNeue"/>
-                                    <color key="textColor" white="0.75" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
-                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                </textFieldCell>
-                            </textField>
                         </subviews>
                         <constraints>
                             <constraint firstAttribute="centerY" secondItem="reu-CB-C0i" secondAttribute="centerY" id="2rj-TD-hfT"/>
-                            <constraint firstAttribute="centerY" secondItem="hsV-nN-jHO" secondAttribute="centerY" constant="2" id="4if-cW-Xnv"/>
                             <constraint firstItem="Wxk-Va-YMt" firstAttribute="centerY" secondItem="reu-CB-C0i" secondAttribute="centerY" id="D5D-79-kC3"/>
                             <constraint firstItem="reu-CB-C0i" firstAttribute="leading" secondItem="0Fa-9p-0gT" secondAttribute="leading" constant="16" id="ELF-J2-Y4x"/>
-                            <constraint firstAttribute="trailing" secondItem="hsV-nN-jHO" secondAttribute="trailing" constant="14" id="J89-aJ-Yya"/>
                             <constraint firstAttribute="height" constant="32" id="Yci-xm-ezL"/>
                             <constraint firstItem="Wxk-Va-YMt" firstAttribute="leading" secondItem="reu-CB-C0i" secondAttribute="trailing" constant="16" id="eMS-g8-tnJ"/>
                         </constraints>
@@ -182,10 +172,10 @@
                         <popUpButton key="view" verticalHuggingPriority="750" id="nOd-hy-BMA">
                             <rect key="frame" x="5" y="14" width="40" height="26"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                            <popUpButtonCell key="cell" type="roundTextured" bezelStyle="texturedRounded" imagePosition="left" alignment="center" lineBreakMode="truncatingTail" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" pullsDown="YES" id="XPC-Wj-xZq">
+                            <popUpButtonCell key="cell" type="roundTextured" bezelStyle="texturedRounded" imagePosition="left" alignment="center" lineBreakMode="truncatingTail" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" pullsDown="YES" autoenablesItems="NO" id="XPC-Wj-xZq">
                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                 <font key="font" metaFont="menu"/>
-                                <menu key="menu" id="52b-Ei-k7f">
+                                <menu key="menu" autoenablesItems="NO" id="52b-Ei-k7f">
                                     <items>
                                         <menuItem state="on" image="NSActionTemplate" hidden="YES" id="vB7-GN-5IN"/>
                                         <menuItem title="Reload Packages" id="e04-3U-hR5">
@@ -204,6 +194,10 @@
                                             <connections>
                                                 <action selector="updatePackageRepoPath:" target="-2" id="GKe-hE-JDF"/>
                                             </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="YMW-h0-fdS"/>
+                                        <menuItem title="Version" enabled="NO" id="ZsI-Jz-bMQ">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
                                         </menuItem>
                                     </items>
                                 </menu>

--- a/Alcatraz/Controllers/ATZPluginWindowController.h
+++ b/Alcatraz/Controllers/ATZPluginWindowController.h
@@ -32,7 +32,7 @@
 @property (assign) IBOutlet NSTableView *tableView;
 @property (weak) IBOutlet NSSegmentedControl *packageTypeSegmentedControl;
 @property (weak) IBOutlet NSSegmentedControl *installationStateSegmentedControl;
-@property (weak) IBOutlet NSTextField *versionTextField;
+@property (weak) IBOutlet NSMenuItem *versionMenuItem;
 
 - (id)initWithBundle:(NSBundle *)bundle;
 

--- a/Alcatraz/Controllers/ATZPluginWindowController.m
+++ b/Alcatraz/Controllers/ATZPluginWindowController.m
@@ -275,7 +275,8 @@ BOOL hasPressedCommandF(NSEvent *event) {
 }
 
 - (void)addVersionToWindow {
-    self.versionTextField.stringValue = [[[Alcatraz sharedPlugin] bundle] infoDictionary][@"CFBundleShortVersionString"];
+    NSString *version = [[[Alcatraz sharedPlugin] bundle] infoDictionary][@"CFBundleShortVersionString"];
+    self.versionMenuItem.title = [NSString stringWithFormat:@"Version %@", version];
 }
 
 #pragma mark - Packages filtering


### PR DESCRIPTION
This is a small UI improvement for the Options menu.

- Adds a down arrow on the right of the cog icon to make it clear the button will display a dropdown menu
- Fix the indentation of the menu items to match the other OS X dropdowns
- Move the version label to the menu

The reasons for the version label move are:
- Most users don't care which version of Alcatraz they're using...
- ... and if they do, they can still find the info easily. But always showing the version number is not necessary.
- It makes space in the window, which I intend to use to display loading and error indicators (for #325, amongst others)

Here's a before / after, and an OS X dropdown for comparison:

![untitled-1](https://cloud.githubusercontent.com/assets/1041337/14410720/cc606fec-ff35-11e5-8826-75a7c84a687c.png)
