### PR TITLE
Make -findXcodeprojPathForPlugin: a bit more flexible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.0
+
+- Plugins are no longer required to have a .xcodeproj filename matching their `name` in `packages.json`
+
 ## 1.1.18
 
 - Fix plugin installation failing if the plugin's name contains `.` dots


### PR DESCRIPTION
- Rename `-findXcodeprojPathForPlugin:` to `-findXcodeprojPathForPackage:`
- Remove usage of `@throw`, use NSError instead
- Make the algorithm finding the plugin's xcodeproj a bit more flexible. Instead of expecting `PluginName.xcodeproj`, it will:
  - Search the plugin repo for .xcodeproj files
  - If only one xcodeproj is found, build that and be happy
  - If multiple xcodeproj are found, try to find one matching the plugin name (old behavior)
  - In all other cases, return `nil`

This will simplify the process of making a plugin work with Alcatraz, as the authors will no longer need to have the name displayed in the plugins list match the xcodeproj filename.

Fixes #452.