### PR TITLE
Clone git repositories with the --recursive option

### DIFF
--- a/Alcatraz/Helpers/ATZGit.h
+++ b/Alcatraz/Helpers/ATZGit.h
@@ -24,6 +24,7 @@
 
 static NSString *const IGNORE_PUSH_CONFIG = @"-c push.default=matching";
 static NSString *const CLONE = @"clone";
+static NSString *const RECURSIVE = @"--recursive";
 static NSString *const FETCH = @"fetch";
 static NSString *const ORIGIN = @"origin";
 static NSString *const BRANCH = @"branch";

--- a/Alcatraz/Helpers/ATZGit.m
+++ b/Alcatraz/Helpers/ATZGit.m
@@ -78,7 +78,7 @@
 + (void)clone:(NSString *)remotePath to:(NSString *)localPath completion:(void (^)(NSString *, NSError *))completion {
     ATZShell *shell = [ATZShell new];
 
-    [shell executeCommand:[self gitExecutablePath] withArguments:@[CLONE, remotePath, localPath, IGNORE_PUSH_CONFIG]
+    [shell executeCommand:[self gitExecutablePath] withArguments:@[CLONE, RECURSIVE, remotePath, localPath, IGNORE_PUSH_CONFIG]
                completion:^(NSString *output, NSError *error) {
                    
         NSLog(@"Git Clone output: %@", output);


### PR DESCRIPTION
Repositories using submodules need to be cloned recursively.

For example, https://github.com/mralexgray/DVTPlugInCompatibilityUUIDifier would fail to build because its AHLaunchCtl submodule was not cloned.