### PR TITLE
Better heuristic for finding the .xcodeproj directory

### DIFF
--- a/Alcatraz.xcodeproj/project.pbxproj
+++ b/Alcatraz.xcodeproj/project.pbxproj
@@ -188,7 +188,10 @@
 				890A4B41171F031300AFE577 /* Frameworks */,
 				890A4B40171F031300AFE577 /* Products */,
 			);
+			indentWidth = 4;
 			sourceTree = "<group>";
+			tabWidth = 4;
+			usesTabs = 0;
 		};
 		890A4B40171F031300AFE577 /* Products */ = {
 			isa = PBXGroup;

--- a/Alcatraz/Controllers/ATZPluginWindowController.m
+++ b/Alcatraz/Controllers/ATZPluginWindowController.m
@@ -209,7 +209,9 @@ typedef NS_ENUM(NSInteger, ATZFilterSegment) {
         [button setFillRatio:progress animated:YES];
     } completion:^(NSError *failure) {
         [ATZStyleKit updateButton:button forPackageState:package animated:YES];
-        if (package.requiresRestart) {
+        if (failure) {
+            [self presentError:failure];
+        } else if (package.requiresRestart) {
             [self postNotificationForInstalledPackage:package];
         }
     }];

--- a/Alcatraz/Controllers/ATZPluginWindowController.m
+++ b/Alcatraz/Controllers/ATZPluginWindowController.m
@@ -85,6 +85,18 @@ typedef NS_ENUM(NSInteger, ATZFilterSegment) {
     return YES;
 }
 
+- (NSError *)willPresentError:(NSError *)error
+{
+    const NSUInteger maxLength = 500;
+    NSString *recoverySuggestion = error.userInfo[NSLocalizedRecoverySuggestionErrorKey];
+    if (recoverySuggestion.length > maxLength) {
+        NSMutableDictionary *userInfo = [error.userInfo mutableCopy];
+        userInfo[NSLocalizedRecoverySuggestionErrorKey] = [[recoverySuggestion substringToIndex:MIN(maxLength, recoverySuggestion.length)] stringByAppendingString:@"…"];
+        return [NSError errorWithDomain:error.domain code:error.code userInfo:userInfo];
+    }
+    return error;
+}
+
 #pragma mark - Bindings
 
 - (IBAction)installPressed:(ATZFillableButton *)button {

--- a/Alcatraz/Helpers/ATZShell.h
+++ b/Alcatraz/Helpers/ATZShell.h
@@ -22,6 +22,13 @@
 
 #import <Foundation/Foundation.h>
 
+static NSString *const ATZShellErrorDomain = @"ATZShellErrorDomain";
+NS_ENUM(NSInteger)
+{
+    ATZShellTerminationStatusError = 666,
+    ATZShellLaunchError = 667
+};
+
 @interface ATZShell : NSObject
 
 - (void)executeCommand:(NSString *)command withArguments:(NSArray *)arguments

--- a/Alcatraz/Helpers/ATZShell.m
+++ b/Alcatraz/Helpers/ATZShell.m
@@ -77,10 +77,8 @@
             if (task.terminationStatus == 0) {
                 completion(output, nil);
             } else {
-                const NSUInteger maxLength = 500;
-                NSString *truncatedOutput = [[output substringToIndex:MIN(maxLength, output.length)] stringByAppendingString:output.length > maxLength ? @"…" : @""];
                 NSString *description = [NSString stringWithFormat:@"Task exited with status %d\n\n%@ %@", task.terminationStatus, task.launchPath, [task.arguments componentsJoinedByString:@" "]];
-                NSDictionary *userInfo = @{ NSLocalizedDescriptionKey: description, NSLocalizedRecoverySuggestionErrorKey: truncatedOutput };
+                NSDictionary *userInfo = @{ NSLocalizedDescriptionKey: description, NSLocalizedRecoverySuggestionErrorKey: output };
                 completion(output, [NSError errorWithDomain:ATZShellErrorDomain code:ATZShellTerminationStatusError userInfo:userInfo]);
             }
         }];

--- a/Alcatraz/Helpers/ATZShell.m
+++ b/Alcatraz/Helpers/ATZShell.m
@@ -77,8 +77,11 @@
             if (task.terminationStatus == 0) {
                 completion(output, nil);
             } else {
-                NSString* reason = [NSString stringWithFormat:@"Task exited with status %d", task.terminationStatus];
-                completion(output, [NSError errorWithDomain:reason code:666 userInfo:@{ NSLocalizedDescriptionKey: reason }]);
+                const NSUInteger maxLength = 500;
+                NSString *truncatedOutput = [[output substringToIndex:MIN(maxLength, output.length)] stringByAppendingString:output.length > maxLength ? @"…" : @""];
+                NSString *description = [NSString stringWithFormat:@"Task exited with status %d\n\n%@ %@", task.terminationStatus, task.launchPath, [task.arguments componentsJoinedByString:@" "]];
+                NSDictionary *userInfo = @{ NSLocalizedDescriptionKey: description, NSLocalizedRecoverySuggestionErrorKey: truncatedOutput };
+                completion(output, [NSError errorWithDomain:ATZShellErrorDomain code:ATZShellTerminationStatusError userInfo:userInfo]);
             }
         }];
         
@@ -92,8 +95,9 @@
         [shellTask launch];
     }
     @catch (NSException *exception) {
-        NSLog(@"Shell command execution failed! %@", exception);
-        completion(nil, [NSError errorWithDomain:exception.reason code:667 userInfo:nil]);
+        NSLog(@"Shell command execution failed! %@ (%@)", exception, shellTask.launchPath);
+        NSDictionary *userInfo = @{ NSLocalizedDescriptionKey: exception.reason, NSLocalizedRecoverySuggestionErrorKey: shellTask.launchPath };
+        completion(nil, [NSError errorWithDomain:ATZShellErrorDomain code:ATZShellLaunchError userInfo:userInfo]);
     }
 }
 

--- a/Alcatraz/Installers/ATZInstaller.h
+++ b/Alcatraz/Installers/ATZInstaller.h
@@ -31,6 +31,13 @@ static NSString *const DOWNLOADING_FORMAT = @"Downloading %@...";
 static NSString *const INSTALLING_FORMAT = @"Installing %@...";
 static NSString *const UPDATING_FORMAT = @"Updating %@...";
 
+static NSString *const ATZInstallerErrorDomain = @"ATZInstallerErrorDomain";
+NS_ENUM(NSInteger)
+{
+    ATZInstallerXcodeProjectNotFoundError = 666,
+    ATZInstallerBundleNotFoundError = 669
+};
+
 @interface ATZInstaller : NSObject
 
 + (instancetype)sharedInstaller;

--- a/Alcatraz/Installers/ATZPluginInstaller.m
+++ b/Alcatraz/Installers/ATZPluginInstaller.m
@@ -169,9 +169,7 @@ static NSString *const PROJECT_PBXPROJ = @"project.pbxproj";
 }
 
 - (NSString *)installNameFromPbxproj:(ATZPackage *)package {
-    NSString *pbxprojPath = [[[[self pathForDownloadedPackage:package]
-                               stringByAppendingPathComponent:package.name] stringByAppendingPathExtension:XCODEPROJ]
-                             stringByAppendingPathComponent:PROJECT_PBXPROJ];
+    NSString *pbxprojPath = [[self findXcodeprojPathForPackage:package error:NULL] stringByAppendingPathComponent:PROJECT_PBXPROJ];
 
     return [ATZPbxprojParser xcpluginNameFromPbxproj:pbxprojPath];
 }

--- a/Alcatraz/Installers/ATZPluginInstaller.m
+++ b/Alcatraz/Installers/ATZPluginInstaller.m
@@ -144,10 +144,6 @@ static NSString *const PROJECT_PBXPROJ = @"project.pbxproj";
         } else if ([fileName.pathExtension isEqualToString:XCODEPROJ]) {
             [allXcodeProjFilenames addObject:directoryEntry];
         }
-
-        if ([directoryEntry isEqualToString:@".git"]) {
-            [enumerator skipDescendants];
-        }
     }
 
     if (allXcodeProjFilenames.count == 1) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.0
+
+- Plugins are no longer required to have a .xcodeproj filename matching their `name` in `packages.json` (#471)
+
 ## 1.1.19
 
 - Fix a crash caused by invalid downloaded image data being displayed anyway. #320 #334 #335 #479


### PR DESCRIPTION
The "Make the Mac Great Again" plugin [would not install](http://twitter.com/zorn/status/737448880472743940) because Alcatraz assumes that the .xcodeproj has the exact same name as the package. This may not be true, for example "Make the Mac Great Again" xcodeproj file is "MakeTheMacGreatAgain.xcodeproj" (without the spaces).

This new heuristic searches for all .xcodeproj and works fine if only one exists in the cloned directory.

I also refactor error handling for better diagnostics when things go wrong.