### PR TITLE
Modify .pullapprove.yml regex

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1,6 +1,6 @@
 approve_by_comment: true
-approve_regex: '^:?(\+1):?'
-reject_regex: '^:?(\-1):?'
+approve_regex: '^(\+1|:\+1:)'
+reject_regex: '^(-1|:-1:)'
 reject_value: -1
 reset_on_push: true
 author_approval: ignored


### PR DESCRIPTION
Hey everybody -- don't want to butt in here but I noticed that PullApprove isn't detecting all of your 👍 's in comments. This should hopefully fix some of that.

A little while ago GitHub changed their UI so that when you type `:` and then pick an emoji from the autocomplete, it inserts the actual Unicode instead of just a `:+1:` string. We made some changes on PullApprove so that people wouldn't have to add Unicode to their yml (`\U0001f44d`), but the `:\+1:` needs to be in the regex in one piece for that to work automatically. I just changed the way your regexes were written so that that is the case.