### PR TITLE
Verify the images we download are valid before displaying them

### DIFF
--- a/Alcatraz/Controllers/ATZPackageTableViewDelegate.m
+++ b/Alcatraz/Controllers/ATZPackageTableViewDelegate.m
@@ -193,7 +193,7 @@ static CGFloat const ATZPackageCellBaseHeight = 116.f;
                                   return;
 
                               NSImage *image = [[NSImage alloc] initWithData:responseData];
-                              if (!image)
+                              if (!image.isValid)
                                   return;
                               
                               [self cacheImage:image forPackage:package];

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.1.19
+
+- Fix a crash caused by invalid downloaded image data being displayed anyway. #320 #334 #335 #479
+  Thanks @piv199 for the help diagnosing the issue.
+
 ## 1.1.18
 
 - Fix plugin installation failing if the plugin's name contains `.` dots


### PR DESCRIPTION
This fixes the crash "Cannot lock focus on image because it is size zero". We won't attempt to display invalid images anymore.

The origin of the invalid image data is still not 100% clear though, but I suspect that the lack of error handling in ATZDownloader (the `error` param of the completion block is always `nil`) might be it.

I'll fix that in another PR when I have more time, and when we get to the root of the problem with @piv199 in https://github.com/alcatraz/Alcatraz/issues/479.

Fixes #320 #334 #335 #479.