### PR TITLE
Update git submodules when updating plugins

### DIFF
--- a/Alcatraz/Helpers/ATZGit.h
+++ b/Alcatraz/Helpers/ATZGit.h
@@ -26,6 +26,7 @@ static NSString *const IGNORE_PUSH_CONFIG = @"-c push.default=matching";
 static NSString *const CLONE = @"clone";
 static NSString *const RECURSIVE = @"--recursive";
 static NSString *const FETCH = @"fetch";
+static NSString *const RECURSE_SUBMODULES_ON_DEMAND = @"--recurse-submodules=on-demand";
 static NSString *const ORIGIN = @"origin";
 static NSString *const BRANCH = @"branch";
 static NSString *const COMMIT = @"commit";
@@ -33,6 +34,8 @@ static NSString *const TAG = @"tag";
 static NSString *const ORIGIN_MASTER = @"origin/master";
 static NSString *const RESET = @"reset";
 static NSString *const HARD = @"--hard";
+static NSString *const SUBMODULE = @"submodule";
+static NSString *const UPDATE = @"update";
 
 @interface ATZGit : NSObject
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 - Support GIF image on screenshot preview (#432)
+- Git submodules are now updated when fetching plugins updates (#484)
 
 ## 1.2.0
 


### PR DESCRIPTION
As discussed in https://github.com/alcatraz/Alcatraz/issues/454, plugins using git submodules need to run `git submodule update` after a `fetch` to update their dependencies to the right commit.

> [**git submodule update**](https://git-scm.com/docs/git-submodule)
> Update the registered submodules to match what the superproject expects by cloning missing submodules and updating the working tree of the submodules.

This is also related to https://github.com/alcatraz/Alcatraz/pull/465, which fixed the initial clone for plugins using submodules.

Changes:
- Add option `--recurse-submodules=on-demand` to the `fetch` command to recursively fetch submodules commits;
- Add command `git submodule update` after successful `git fetch` and `git reset --hard` to make the submodules checkout the right commits.


Note: Not a big fan of the pyramid-callbacks-style in `+[ATZGit updateLocalProject:revision:completion:]`, if you have a better idea, I'll take it :)