### PR TITLE
Add support for Xcode 8.0, for those who removed the Xcode app signature

### DIFF
--- a/Alcatraz/Alcatraz-Info.plist
+++ b/Alcatraz/Alcatraz-Info.plist
@@ -45,6 +45,7 @@
 		<string>F41BD31E-2683-44B8-AE7F-5F09E919790E</string>
 		<string>E71C2CFE-BFD8-4044-8F06-00AE685A406C</string>
 		<string>ACA8656B-FEA8-4B6D-8E4A-93F4C95C362C</string>
+		<string>8A66E736-A720-4B3C-92F1-33D9962C69DF</string>
 	</array>
 	<key>XC4Compatible</key>
 	<true/>


### PR DESCRIPTION
I know about #475, but those of us who have removed the app signature from Xcode 8 would still like to use Alcatraz. Therefore we should add the Xcode 8 DVTPlugInCompatibilityUUID because it won't cause any issues for those who have not unsigned Xcode 8.
