### PR TITLE
Update CHANGELOG.md with Xcode 8 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,8 @@
-## Unreleased
-- Support GIF image on screenshot preview (#432)
-
 ## 1.2.0
 
 - Plugins are no longer required to have a .xcodeproj filename matching their `name` in `packages.json` (#471)
+- Support GIF image on screenshot preview (#432)
+- Support for Xcode 8 (#488, see also #475 on why it might not work for you)
 
 ## 1.1.19
 


### PR DESCRIPTION
- Add mention of Xcode 8 support, with ref to #475
- Remove version 1.2.0 which we never got around to release, and move its content under `## Unreleased`