### PR TITLE
Add Xcode 8.2 compatibility UUID

### DIFF
--- a/Alcatraz/Alcatraz-Info.plist
+++ b/Alcatraz/Alcatraz-Info.plist
@@ -47,6 +47,7 @@
 		<string>ACA8656B-FEA8-4B6D-8E4A-93F4C95C362C</string>
 		<string>8A66E736-A720-4B3C-92F1-33D9962C69DF</string>
 		<string>65C57D32-1E9B-44B8-8C04-A27BA7AAE2C4</string>
+		<string>E0A62D1F-3C18-4D74-BFE5-A4167D643966</string>
 	</array>
 	<key>XC4Compatible</key>
 	<true/>


### PR DESCRIPTION
I tried with Xcode 8.2.1 and it works too as it already discussed here: https://github.com/alcatraz/Alcatraz/issues/498